### PR TITLE
Feat/pre funded accounts

### DIFF
--- a/contracts/crucible/Cargo.toml
+++ b/contracts/crucible/Cargo.toml
@@ -11,5 +11,5 @@ default = ["derive"]
 derive = ["dep:crucible-macros"]
 
 [dependencies]
-soroban-sdk.workspace = true
+soroban-sdk = { workspace = true, features = ["testutils"] }
 crucible-macros = { workspace = true, optional = true }

--- a/contracts/crucible/src/account.rs
+++ b/contracts/crucible/src/account.rs
@@ -1,1 +1,181 @@
-// AccountHandle and AccountBuilder will go here
+//! Account management for Soroban testing.
+//!
+//! Provides `AccountHandle` - a wrapper around a Soroban `Address` with
+//! keypair signing support and balance helpers, and `AccountBuilder` for
+//! easy pre-funded account creation.
+
+use soroban_sdk::Address;
+use crate::env::{MockEnv, Stroops};
+use crate::token::MockToken;
+
+/// A handle to a Soroban account used in tests.
+pub struct AccountHandle {
+    mock_env: MockEnv,
+    name: String,
+    address: Address,
+}
+
+impl AccountHandle {
+    /// Internal constructor for use by `AccountBuilder` or `MockEnv`.
+    pub(crate) fn new(mock_env: MockEnv, name: String, address: Address) -> Self {
+        Self { mock_env, name, address }
+    }
+
+    /// Returns the account's name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the account's address.
+    pub fn address(&self) -> Address {
+        self.address.clone()
+    }
+
+    /// Returns the account's XLM balance (in stroops).
+    pub fn xlm_balance(&self) -> i128 {
+        let xlm_address = self.mock_env.xlm_token_address()
+            .expect("XLM token address not set in environment. Use MockToken::xlm(&env) or MockEnvBuilder::with_account to set it.");
+        let xlm_token = MockToken::from_address(self.mock_env.inner(), xlm_address);
+        xlm_token.balance(&self.address)
+    }
+
+    /// Returns the account's balance in a given token.
+    pub fn token_balance(&self, token: &MockToken) -> i128 {
+        token.balance(&self.address)
+    }
+}
+
+impl core::ops::Deref for AccountHandle {
+    type Target = Address;
+
+    fn deref(&self) -> &Self::Target {
+        &self.address
+    }
+}
+
+impl AsRef<Address> for AccountHandle {
+    fn as_ref(&self) -> &Address {
+        &self.address
+    }
+}
+
+/// A builder for creating pre-funded accounts.
+pub struct AccountBuilder<'env> {
+    env: &'env MockEnv,
+    name: String,
+    xlm_balance: Stroops,
+    token_balances: Vec<(&'env MockToken, i128)>,
+}
+
+impl<'env> AccountBuilder<'env> {
+    /// Creates a new `AccountBuilder` for the given environment.
+    pub fn new(env: &'env MockEnv) -> Self {
+        Self {
+            env,
+            name: "unnamed".to_string(),
+            xlm_balance: Stroops::from(0),
+            token_balances: Vec::new(),
+        }
+    }
+
+    /// Sets the name of the account for later retrieval via `MockEnv::account(name)`.
+    pub fn name(mut self, name: &str) -> Self {
+        self.name = name.to_string();
+        self
+    }
+
+    /// Funds the account with the given amount of XLM.
+    pub fn fund_xlm(mut self, amount: Stroops) -> Self {
+        self.xlm_balance = amount;
+        self
+    }
+
+    /// Funds the account with the given amount of a specific token.
+    pub fn fund_token(mut self, token: &'env MockToken, amount: i128) -> Self {
+        self.token_balances.push((token, amount));
+        self
+    }
+
+    /// Builds the account, registering it in the environment and funding it.
+    pub fn build(self) -> AccountHandle {
+        // 1. Create a mock auth contract for the account (represented as an address)
+        let address = self.env.inner().register_contract(
+            None,
+            soroban_sdk::testutils::MockAuthContract {},
+        );
+
+        // 2. Fund XLM if requested
+        if self.xlm_balance.as_stroops() > 0 {
+            let xlm = MockToken::xlm(self.env);
+            xlm.mint(&address, self.xlm_balance.as_stroops());
+        }
+
+        // 3. Fund other tokens
+        for (token, amount) in self.token_balances {
+            token.mint(&address, amount);
+        }
+
+        // 4. Register in MockEnv
+        self.env.register_account(&self.name, address.clone());
+
+                AccountHandle::new(self.env.clone(), self.name, address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    #[test]
+    fn test_account_creation_and_funding() {
+        let env = MockEnv::builder()
+            .with_account("alice", Stroops::xlm(100))
+            .with_account("bob", Stroops::xlm(50))
+            .build();
+
+        let alice = env.account("alice");
+        let bob = env.account("bob");
+
+        assert_eq!(alice.xlm_balance(), Stroops::xlm(100).as_stroops());
+        assert_eq!(bob.xlm_balance(), Stroops::xlm(50).as_stroops());
+    }
+
+    #[test]
+    fn test_token_transfer_between_accounts() {
+        let env = MockEnv::builder()
+            .with_account("alice", Stroops::xlm(100))
+            .with_account("bob", Stroops::xlm(100))
+            .build();
+        env.mock_all_auths();
+
+        let alice = env.account("alice");
+        let bob = env.account("bob");
+        let xlm = MockToken::xlm(&env);
+
+                // Perform transfer using the addresses
+        xlm.transfer(&*alice, &*bob, 20_000_000);
+
+        assert_eq!(alice.xlm_balance(), 980_000_000);
+        assert_eq!(bob.xlm_balance(), 1_020_000_000);
+    }
+
+    #[test]
+    fn test_account_builder_fluent() {
+        let env = MockEnv::builder().build();
+        let usdc = MockToken::new(&env, "USDC", 6);
+        
+        let charlie = AccountBuilder::new(&env)
+            .name("charlie")
+            .fund_xlm(Stroops::xlm(10))
+            .fund_token(&usdc, 1000)
+            .build();
+
+        assert_eq!(charlie.xlm_balance(), Stroops::xlm(10).as_stroops());
+        assert_eq!(charlie.token_balance(&usdc), 1000);
+        
+        // Should be retrievable from env
+        let charlie_ref = env.account("charlie");
+        assert_eq!(charlie_ref.address(), charlie.address());
+    }
+}
+

--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -3,7 +3,10 @@
 //! Provides `MockEnv` - a wrapper around `soroban_sdk::Env` with convenient
 //! helpers for testing, and `MockEnvBuilder` for fluent environment construction.
 
-use soroban_sdk::{testutils::Ledger, Address, Env};
+use soroban_sdk::{
+    testutils::{Events, Ledger},
+    Address, Env, IntoVal, Val, Vec as SorobanVec,
+};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -218,6 +221,44 @@ impl MockEnv {
         self.contract_ids
             .borrow_mut()
             .insert(type_name.to_string(), address);
+    }
+
+    /// Returns all events emitted during the test.
+    ///
+    /// Each event is a tuple consisting of (contract_address, topics, data).
+    pub fn events_all(&self) -> SorobanVec<(Address, SorobanVec<Val>, Val)> {
+        self.inner.events().all()
+    }
+
+    /// Returns events matching the given topics.
+    ///
+    /// Match is a partial match on topics — all topics in the filter must be
+    /// present at the start of the event's topics.
+    pub fn events_matching<T>(&self, topics: T) -> SorobanVec<(Address, SorobanVec<Val>, Val)>
+    where
+        T: IntoVal<Env, SorobanVec<Val>>,
+    {
+        let filter_topics: SorobanVec<Val> = topics.into_val(&self.inner);
+        let all_events = self.inner.events().all();
+        let mut matching = SorobanVec::new(&self.inner);
+
+        for event in all_events.iter() {
+            let topics = &event.1;
+            if topics.len() < filter_topics.len() {
+                continue;
+            }
+            let mut matches = true;
+            for (i, filter_topic) in filter_topics.iter().enumerate() {
+                if format!("{:?}", filter_topic) != format!("{:?}", topics.get(i as u32).unwrap()) {
+                    matches = false;
+                    break;
+                }
+            }
+            if matches {
+                matching.push_back(event);
+            }
+        }
+        matching
     }
 
     /// Check if cost tracking is enabled.

--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -3,6 +3,7 @@
 //! Provides `MockEnv` - a wrapper around `soroban_sdk::Env` with convenient
 //! helpers for testing, and `MockEnvBuilder` for fluent environment construction.
 
+use crate::account::AccountHandle;
 use soroban_sdk::{
     testutils::{Events, Ledger},
     Address, Env, IntoVal, Val, Vec as SorobanVec,
@@ -106,10 +107,12 @@ impl Stroops {
 }
 
 /// A wrapper around the Soroban test environment with additional helpers.
+#[derive(Clone)]
 pub struct MockEnv {
     inner: Env,
     accounts: Rc<RefCell<HashMap<String, Address>>>,
     contract_ids: Rc<RefCell<HashMap<String, Address>>>,
+    xlm_token_address: Rc<RefCell<Option<Address>>>,
     track_costs: bool,
 }
 
@@ -124,13 +127,15 @@ impl MockEnv {
         MockEnvBuilder::new()
     }
 
-    /// Get an account address by name.
-    pub fn account(&self, name: &str) -> Address {
-        self.accounts
+    /// Get an account handle by name.
+    pub fn account(&self, name: &str) -> AccountHandle {
+        let address = self.accounts
             .borrow()
             .get(name)
             .cloned()
-            .unwrap_or_else(|| panic!("Account '{}' not found", name))
+            .unwrap_or_else(|| panic!("Account '{}' not found. Ensure it was registered via MockEnvBuilder or AccountBuilder.", name));
+        
+                AccountHandle::new(self.clone(), name.to_string(), address)
     }
 
     /// Get a contract ID by type.
@@ -261,6 +266,16 @@ impl MockEnv {
         matching
     }
 
+    /// Set the XLM token address for the environment.
+    pub fn set_xlm_token_address(&self, address: Address) {
+        *self.xlm_token_address.borrow_mut() = Some(address);
+    }
+
+    /// Get the XLM token address for the environment, if set.
+    pub fn xlm_token_address(&self) -> Option<Address> {
+        self.xlm_token_address.borrow().clone()
+    }
+
     /// Check if cost tracking is enabled.
     pub fn track_costs(&self) -> bool {
         self.track_costs
@@ -273,6 +288,7 @@ impl Default for MockEnv {
             inner: Env::default(),
             accounts: Rc::new(RefCell::new(HashMap::new())),
             contract_ids: Rc::new(RefCell::new(HashMap::new())),
+            xlm_token_address: Rc::new(RefCell::new(None)),
             track_costs: false,
         }
     }
@@ -281,12 +297,14 @@ impl Default for MockEnv {
 /// Builder for constructing a `MockEnv` with custom configuration.
 pub struct MockEnvBuilder {
     env: MockEnv,
+    account_configs: Vec<(String, Stroops)>,
 }
 
 impl MockEnvBuilder {
     fn new() -> Self {
         Self {
             env: MockEnv::default(),
+            account_configs: Vec::new(),
         }
     }
 
@@ -361,19 +379,8 @@ impl MockEnvBuilder {
     }
 
     /// Add a named account with XLM balance.
-    pub fn with_account(self, name: &str, balance: Stroops) -> Self {
-        // Create a mock auth contract for the account
-        let address = self
-            .env
-            .inner
-            .register_contract::<soroban_sdk::testutils::MockAuthContract>(
-                None,
-                soroban_sdk::testutils::MockAuthContract {},
-            );
-        self.env.register_account(name, address);
-        // Note: XLM balance tracking would require ledger entry manipulation
-        // For now, we store the balance conceptually
-        let _ = balance; // Use the balance parameter
+    pub fn with_account(mut self, name: &str, balance: Stroops) -> Self {
+        self.account_configs.push((name.to_string(), balance));
         self
     }
 
@@ -385,6 +392,14 @@ impl MockEnvBuilder {
 
     /// Build the `MockEnv`.
     pub fn build(self) -> MockEnv {
+        // We'll use the builder's env to construct the accounts.
+        // This ensures they are registered in the MockEnv.
+        for (name, balance) in self.account_configs {
+            crate::account::AccountBuilder::new(&self.env)
+                .name(&name)
+                .fund_xlm(balance)
+                .build();
+        }
         self.env
     }
 }

--- a/contracts/crucible/src/lib.rs
+++ b/contracts/crucible/src/lib.rs
@@ -1,3 +1,4 @@
+pub use soroban_sdk;
 pub mod account;
 pub mod cost;
 pub mod env;

--- a/contracts/crucible/src/macros.rs
+++ b/contracts/crucible/src/macros.rs
@@ -1,1 +1,224 @@
-// assertion macros will go here
+/// Assert that a contract event was emitted.
+///
+/// This macro supports several forms for flexible event assertion:
+///
+/// - `assert_emitted!(env, topics: (...), data: value)`
+/// - `assert_emitted!(env, contract: addr, topics: (...), data: value)`
+/// - `assert_emitted!(env, topics: (...), count: n)`
+/// - `assert_emitted!(env, topics: (...), at_index: n, data: value)`
+///
+/// Matching is a partial match on topics — all topics in the filter must be
+/// present at the start of the event's topics.
+#[macro_export]
+macro_rules! assert_emitted {
+    // Form 4: with at_index and data
+    ($env:expr, topics: $topics:expr, at_index: $index:expr, data: $data:expr $(,)?) => {
+        {
+            let env = &$env;
+            let topics = $topics;
+            let matching = env.events_matching(topics.clone());
+            let actual_count = matching.len();
+            let index: u32 = $index;
+            if index >= actual_count {
+                panic!("Expected event at index {} for topics {:?}, but only found {}.\nActual emitted events: {:?}", index, topics, actual_count, env.events_all());
+            }
+            let event = matching.get(index).unwrap();
+                        let expected_data: $crate::soroban_sdk::Val = $crate::soroban_sdk::IntoVal::into_val(&$data, env.inner());
+                                                if format!("{:?}", event.2) != format!("{:?}", expected_data) {
+                panic!("Event at index {} for topics {:?} had wrong data.\nExpected: {:?}\nActual: {:?}\nActual emitted events: {:?}", index, topics, $data, event.2, env.events_all());
+            }
+        }
+    };
+    // Form 3: with count
+    ($env:expr, topics: $topics:expr, count: $count:expr $(,)?) => {
+        {
+            let env = &$env;
+            let topics = $topics;
+            let matching = env.events_matching(topics.clone());
+            let expected_count: u32 = $count;
+            if matching.len() != expected_count {
+                panic!("Expected {} events matching topics {:?}, but found {}.\nActual emitted events: {:?}", expected_count, topics, matching.len(), env.events_all());
+            }
+        }
+    };
+    // Form 2: with contract, topics, and data
+    ($env:expr, contract: $contract:expr, topics: $topics:expr, data: $data:expr $(,)?) => {
+        {
+            let env = &$env;
+            let topics = $topics;
+            let matching = env.events_matching(topics.clone());
+            let contract_addr: $crate::soroban_sdk::Address = $contract.clone();
+            let mut found = false;
+            let mut found_count = 0;
+                        let expected_data: $crate::soroban_sdk::Val = $crate::soroban_sdk::IntoVal::into_val(&$data, env.inner());
+            for event in matching.iter() {
+                if event.0 == contract_addr {
+                    found_count += 1;
+                                                                                if format!("{:?}", event.2) == format!("{:?}", expected_data) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if !found {
+                if found_count == 0 {
+                    panic!("No events from contract {:?} matched topics {:?}.\nActual emitted events: {:?}", $contract, topics, env.events_all());
+                } else {
+                    panic!("None of the {} events from contract {:?} matching topics {:?} had correct data.\nExpected: {:?}\nActual emitted events: {:?}", found_count, $contract, topics, $data, env.events_all());
+                }
+            }
+        }
+    };
+    // Form 1: topics and data
+    ($env:expr, topics: $topics:expr, data: $data:expr $(,)?) => {
+        {
+            let env = &$env;
+            let topics = $topics;
+            let matching = env.events_matching(topics.clone());
+            if matching.len() == 0 {
+                panic!("Expected event matching topics {:?}, but found none.\nActual emitted events: {:?}", topics, env.events_all());
+            }
+                        let expected_data: $crate::soroban_sdk::Val = $crate::soroban_sdk::IntoVal::into_val(&$data, env.inner());
+            let mut found = false;
+                                                for event in matching.iter() {
+                if format!("{:?}", event.2) == format!("{:?}", expected_data) {
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                panic!("No event matching topics {:?} had data {:?}.\nActual emitted events: {:?}", topics, $data, env.events_all());
+            }
+        }
+    };
+}
+
+/// Assert that a contract event was not emitted.
+#[macro_export]
+macro_rules! assert_not_emitted {
+    // Basic topics version
+    ($env:expr, topics: $topics:expr $(,)?) => {
+        {
+            let env = &$env;
+            let topics = $topics;
+            let matching = env.events_matching(topics.clone());
+            if matching.len() > 0 {
+                panic!("Expected no events matching topics {:?}, but found {}.\nActual emitted events: {:?}", topics, matching.len(), env.events_all());
+            }
+        }
+    };
+    // Contract filtered version
+    ($env:expr, contract: $contract:expr, topics: $topics:expr $(,)?) => {
+        {
+            let env = &$env;
+            let topics = $topics;
+            let matching = env.events_matching(topics.clone());
+            let contract_addr: $crate::soroban_sdk::Address = $contract.clone();
+            let mut found_count = 0;
+            for event in matching.iter() {
+                if event.0 == contract_addr {
+                    found_count += 1;
+                }
+            }
+                        if found_count > 0 {
+                panic!("Expected no events from contract {:?} matching topics {:?}, but found {}.\nActual emitted events: {:?}", $contract, topics, found_count, env.events_all());
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+    use soroban_sdk::{contract, contractimpl, symbol_short, testutils::Address as _, Address, Env};
+
+    #[contract]
+    #[derive(Default, Debug)]
+    pub struct TestContract;
+
+    #[contractimpl]
+    impl TestContract {
+        pub fn fire(env: Env, value: u32) {
+            env.events().publish((symbol_short!("test"),), value);
+        }
+        pub fn fire_multi(env: Env, value: u32) {
+            env.events().publish((symbol_short!("v1"), symbol_short!("data")), value);
+            env.events().publish((symbol_short!("v1"), symbol_short!("data")), value + 1);
+        }
+    }
+
+    #[test]
+    fn test_macro_emitted_success() {
+        let env = MockEnv::builder()
+            .with_contract::<TestContract>()
+            .build();
+        let contract_id = env.contract_id::<TestContract>();
+        let client = TestContractClient::new(env.inner(), &contract_id);
+
+        client.fire(&42);
+
+        // Different forms
+        assert_emitted!(env, topics: (symbol_short!("test"),), data: 42_u32);
+        assert_emitted!(env, contract: &contract_id, topics: (symbol_short!("test"),), data: 42_u32);
+        assert_emitted!(env, topics: (symbol_short!("test"),), count: 1);
+        assert_emitted!(env, topics: (symbol_short!("test"),), at_index: 0, data: 42_u32);
+    }
+
+    #[test]
+    fn test_macro_multi_success() {
+        let env = MockEnv::builder()
+            .with_contract::<TestContract>()
+            .build();
+        let contract_id = env.contract_id::<TestContract>();
+        let client = TestContractClient::new(env.inner(), &contract_id);
+
+        client.fire_multi(&10);
+
+        assert_emitted!(env, topics: (symbol_short!("v1"),), count: 2);
+        assert_emitted!(env, topics: (symbol_short!("v1"), symbol_short!("data")), at_index: 0, data: 10_u32);
+        assert_emitted!(env, topics: (symbol_short!("v1"), symbol_short!("data")), at_index: 1, data: 11_u32);
+    }
+
+    #[test]
+    fn test_macro_not_emitted_success() {
+        let env = MockEnv::builder()
+            .with_contract::<TestContract>()
+            .build();
+        let contract_id = env.contract_id::<TestContract>();
+        let client = TestContractClient::new(env.inner(), &contract_id);
+
+        client.fire(&42);
+
+        assert_not_emitted!(env, topics: (symbol_short!("missing"),));
+        assert_not_emitted!(env, contract: &Address::generate(env.inner()), topics: (symbol_short!("test"),));
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected 2 events matching topics (Symbol(test),)")]
+    fn test_macro_panic_wrong_count() {
+        let env = MockEnv::builder()
+            .with_contract::<TestContract>()
+            .build();
+        let contract_id = env.contract_id::<TestContract>();
+        let client = TestContractClient::new(env.inner(), &contract_id);
+
+        client.fire(&42);
+
+        assert_emitted!(env, topics: (symbol_short!("test"),), count: 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "No event matching topics (Symbol(test),) had data 43")]
+    fn test_macro_panic_wrong_data() {
+        let env = MockEnv::builder()
+            .with_contract::<TestContract>()
+            .build();
+        let contract_id = env.contract_id::<TestContract>();
+        let client = TestContractClient::new(env.inner(), &contract_id);
+
+        client.fire(&42);
+
+        assert_emitted!(env, topics: (symbol_short!("test"),), data: 43_u32);
+    }
+}
+

--- a/contracts/crucible/src/prelude.rs
+++ b/contracts/crucible/src/prelude.rs
@@ -3,6 +3,8 @@
 //! This module provides convenient access to all commonly used types
 //! and utilities from the crucible testing framework.
 
+pub use crate::account::AccountBuilder;
+pub use crate::account::AccountHandle;
 pub use crate::env::Duration;
 pub use crate::env::MockEnv;
 pub use crate::env::MockEnvBuilder;

--- a/contracts/crucible/src/token.rs
+++ b/contracts/crucible/src/token.rs
@@ -33,6 +33,10 @@ impl MockToken {
     /// let xlm = MockToken::xlm(&env);
     /// ```
     pub fn xlm(env: &MockEnv) -> Self {
+        if let Some(address) = env.xlm_token_address() {
+            return Self::from_address(env.inner(), address);
+        }
+
         // Create an admin for the XLM token
         let _admin = env
             .inner()
@@ -41,10 +45,20 @@ impl MockToken {
                 soroban_sdk::testutils::MockAuthContract {},
             );
         let sac = env.inner().register_stellar_asset_contract_v2(_admin);
-
+        let address = sac.address();
+        env.set_xlm_token_address(address.clone());
+        
         Self {
             env: env.inner().clone(),
-            address: sac.address(),
+            address,
+        }
+    }
+
+    /// Creates a MockToken from an existing address.
+    pub fn from_address(env: &Env, address: Address) -> Self {
+        Self {
+            env: env.clone(),
+            address,
         }
     }
 
@@ -210,116 +224,116 @@ mod tests {
     #[test]
     fn test_mint_and_check_balance() {
         let env = MockEnv::builder()
-            .with_account("alice", Stroops::xlm(100))
+                        .with_account("alice", Stroops::from(0))
             .build();
 
         let token = MockToken::xlm(&env);
         let alice = env.account("alice");
 
-        // Mint tokens to alice
-        token.mint(&alice, 500_000);
+                // Mint tokens to alice
+        token.mint(&alice.address(), 500_000);
 
         // Check balance
-        assert_eq!(token.balance(&alice), 500_000);
+        assert_eq!(token.balance(&alice.address()), 500_000);
     }
 
     #[test]
     fn test_transfer_between_accounts() {
         let env = MockEnv::builder()
-            .with_account("alice", Stroops::xlm(100))
-            .with_account("bob", Stroops::xlm(100))
+                        .with_account("alice", Stroops::from(0))
+            .with_account("bob", Stroops::from(0))
             .build();
 
         let token = MockToken::xlm(&env);
         let alice = env.account("alice");
         let bob = env.account("bob");
 
-        // Mint tokens to alice
-        token.mint(&alice, 1_000_000);
-        assert_eq!(token.balance(&alice), 1_000_000);
+                // Mint tokens to alice
+        token.mint(&alice.address(), 1_000_000);
+        assert_eq!(token.balance(&alice.address()), 1_000_000);
 
         // Transfer from alice to bob
-        token.transfer(&alice, &bob, 400_000);
+        token.transfer(&alice.address(), &bob.address(), 400_000);
 
         // Verify both balances
-        assert_eq!(token.balance(&alice), 600_000);
-        assert_eq!(token.balance(&bob), 400_000);
+        assert_eq!(token.balance(&alice.address()), 600_000);
+        assert_eq!(token.balance(&bob.address()), 400_000);
     }
 
     #[test]
     fn test_approve_and_check_allowance() {
         let env = MockEnv::builder()
-            .with_account("alice", Stroops::xlm(100))
-            .with_account("spender", Stroops::xlm(100))
+                        .with_account("alice", Stroops::from(0))
+            .with_account("spender", Stroops::from(0))
             .build();
 
         let token = MockToken::xlm(&env);
         let alice = env.account("alice");
         let spender = env.account("spender");
 
-        // Mint tokens to alice
-        token.mint(&alice, 1_000_000);
+                // Mint tokens to alice
+        token.mint(&alice.address(), 1_000_000);
 
         // Approve spender
-        token.approve(&alice, &spender, 500_000, 1000);
+        token.approve(&alice.address(), &spender.address(), 500_000, 1000);
 
         // Check allowance
-        assert_eq!(token.allowance(&alice, &spender), 500_000);
+        assert_eq!(token.allowance(&alice.address(), &spender.address()), 500_000);
     }
 
     #[test]
     fn test_clawback_reduces_balance() {
         let env = MockEnv::builder()
-            .with_account("alice", Stroops::xlm(100))
+                        .with_account("alice", Stroops::from(0))
             .build();
 
         let token = MockToken::xlm(&env);
         let alice = env.account("alice");
 
-        // Mint tokens to alice
-        token.mint(&alice, 1_000_000);
-        assert_eq!(token.balance(&alice), 1_000_000);
+                // Mint tokens to alice
+        token.mint(&alice.address(), 1_000_000);
+        assert_eq!(token.balance(&alice.address()), 1_000_000);
 
         // Burn some tokens (similar effect to clawback - reduces balance)
         // Note: clawback requires special issuer flags to be set on the SAC
-        token.burn(&alice, 300_000);
+        token.burn(&alice.address(), 300_000);
 
         // Verify balance reduced
-        assert_eq!(token.balance(&alice), 700_000);
+        assert_eq!(token.balance(&alice.address()), 700_000);
     }
 
     #[test]
     fn test_burn_reduces_balance() {
         let env = MockEnv::builder()
-            .with_account("alice", Stroops::xlm(100))
+                        .with_account("alice", Stroops::from(0))
             .build();
 
         let token = MockToken::xlm(&env);
         let alice = env.account("alice");
 
-        // Mint tokens to alice
-        token.mint(&alice, 1_000_000);
-        assert_eq!(token.balance(&alice), 1_000_000);
+                // Mint tokens to alice
+        token.mint(&alice.address(), 1_000_000);
+        assert_eq!(token.balance(&alice.address()), 1_000_000);
 
         // Burn some tokens
-        token.burn(&alice, 200_000);
+        token.burn(&alice.address(), 200_000);
 
         // Verify balance reduced
-        assert_eq!(token.balance(&alice), 800_000);
+        assert_eq!(token.balance(&alice.address()), 800_000);
     }
 
     #[test]
     fn test_new_token_with_symbol_and_decimals() {
         let env = MockEnv::builder()
-            .with_account("alice", Stroops::xlm(100))
+                        .with_account("alice", Stroops::from(0))
             .build();
 
         let token = MockToken::new(&env, "USDC", 6);
         let alice = env.account("alice");
 
-        // Mint tokens
-        token.mint(&alice, 1_000_000_000); // 1000 USDC with 6 decimals
+                // Mint tokens
+        token.mint(&alice.address(), 1_000_000_000); // 1000 USDC with 6 decimals
 
-        assert_eq!(token.balance(&alice), 1_000_000_000);
+        assert_eq!(token.balance(&alice.address()), 1_000_000_000);
     }
 }

--- a/contracts/crucible/test_snapshots/account/tests/test_account_builder_fluent.1.json
+++ b/contracts/crucible/test_snapshots/account/tests/test_account_builder_fluent.1.json
@@ -1,0 +1,1309 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100000000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+                "balance": 0,
+                "seq_num": 0,
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 0,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+                "balance": 0,
+                "seq_num": 0,
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 0,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000002"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 100000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000005"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1"
+              },
+              {
+                "symbol": "init_asset"
+              }
+            ],
+            "data": {
+              "bytes": "0000000161616100000000000000000000000000000000000000000000000000000000000000000000000002"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init_asset"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1"
+              },
+              {
+                "symbol": "set_admin"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "set_admin"
+              },
+              {
+                "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "set_admin"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "init_asset"
+              }
+            ],
+            "data": {
+              "bytes": "0000000161616100000000000000000000000000000000000000000000000000000000000000000000000005"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init_asset"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "set_admin"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "set_admin"
+              },
+              {
+                "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "set_admin"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100000000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "mint"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 100000000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "mint"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 1000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 100000000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "48f1b6b8bc0d60f7140dd49b6120fbaf3cdbab2adaeea631313d9f0bae9532f1",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 1000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/crucible/test_snapshots/account/tests/test_account_creation_and_funding.1.json
+++ b/contracts/crucible/test_snapshots/account/tests/test_account_creation_and_funding.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0
   },
   "auth": [
@@ -47,12 +47,39 @@
           "sub_invocations": []
         }
       ]
-    ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500000000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
   ],
   "ledger": {
     "protocol_version": 21,
-    "sequence_number": 1000,
-    "timestamp": 1700000000,
+    "sequence_number": 0,
+    "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -117,7 +144,7 @@
             },
             "ext": "v0"
           },
-          6312999
+          6311999
         ]
       ],
       [
@@ -149,7 +176,7 @@
             },
             "ext": "v0"
           },
-          5095
+          4095
         ]
       ],
       [
@@ -181,7 +208,40 @@
             },
             "ext": "v0"
           },
-          5095
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
         ]
       ],
       [
@@ -214,7 +274,39 @@
             },
             "ext": "v0"
           },
-          6312999
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -287,7 +379,80 @@
             },
             "ext": "v0"
           },
-          519400
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 500000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
         ]
       ],
       [
@@ -399,7 +564,7 @@
             },
             "ext": "v0"
           },
-          121960
+          120960
         ]
       ],
       [
@@ -420,7 +585,7 @@
             },
             "ext": "v0"
           },
-          5095
+          4095
         ]
       ]
     ]
@@ -630,6 +795,199 @@
               }
             ],
             "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500000000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "mint"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 500000000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 1000000000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 500000000
+              }
+            }
           }
         }
       },

--- a/contracts/crucible/test_snapshots/account/tests/test_token_transfer_between_accounts.1.json
+++ b/contracts/crucible/test_snapshots/account/tests/test_token_transfer_between_accounts.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0
   },
   "auth": [
@@ -47,12 +47,67 @@
           "sub_invocations": []
         }
       ]
-    ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000000000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "transfer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 20000000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
   ],
   "ledger": {
     "protocol_version": 21,
-    "sequence_number": 1000,
-    "timestamp": 1700000000,
+    "sequence_number": 0,
+    "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -117,7 +172,7 @@
             },
             "ext": "v0"
           },
-          6312999
+          6311999
         ]
       ],
       [
@@ -149,7 +204,40 @@
             },
             "ext": "v0"
           },
-          5095
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
         ]
       ],
       [
@@ -181,7 +269,40 @@
             },
             "ext": "v0"
           },
-          5095
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
         ]
       ],
       [
@@ -214,7 +335,39 @@
             },
             "ext": "v0"
           },
-          6312999
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
         ]
       ],
       [
@@ -261,7 +414,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 1000000000
+                          "lo": 980000000
                         }
                       }
                     },
@@ -287,7 +440,80 @@
             },
             "ext": "v0"
           },
-          519400
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1020000000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
         ]
       ],
       [
@@ -399,7 +625,7 @@
             },
             "ext": "v0"
           },
-          121960
+          120960
         ]
       ],
       [
@@ -420,7 +646,7 @@
             },
             "ext": "v0"
           },
-          5095
+          4095
         ]
       ]
     ]
@@ -630,6 +856,291 @@
               }
             ],
             "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000000000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "mint"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 1000000000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 20000000
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "transfer"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 20000000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 980000000
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "692c360a04a982db02db346a106cbf008ad9e058c384bdaaf77bc0c48799b3a4",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 1020000000
+              }
+            }
           }
         }
       },

--- a/contracts/crucible/test_snapshots/macros/tests/test_macro_emitted_success.1.json
+++ b/contracts/crucible/test_snapshots/macros/tests/test_macro_emitted_success.1.json
@@ -1,0 +1,143 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "fire"
+              }
+            ],
+            "data": {
+              "u32": 42
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "test"
+              }
+            ],
+            "data": {
+              "u32": 42
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "fire"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/crucible/test_snapshots/macros/tests/test_macro_multi_success.1.json
+++ b/contracts/crucible/test_snapshots/macros/tests/test_macro_multi_success.1.json
@@ -1,0 +1,169 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "fire_multi"
+              }
+            ],
+            "data": {
+              "u32": 10
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "v1"
+              },
+              {
+                "symbol": "data"
+              }
+            ],
+            "data": {
+              "u32": 10
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "v1"
+              },
+              {
+                "symbol": "data"
+              }
+            ],
+            "data": {
+              "u32": 11
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "fire_multi"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/crucible/test_snapshots/macros/tests/test_macro_not_emitted_success.1.json
+++ b/contracts/crucible/test_snapshots/macros/tests/test_macro_not_emitted_success.1.json
@@ -1,0 +1,143 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "fire"
+              }
+            ],
+            "data": {
+              "u32": 42
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "test"
+              }
+            ],
+            "data": {
+              "u32": 42
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "fire"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/crucible/test_snapshots/macros/tests/test_macro_panic_wrong_count.1.json
+++ b/contracts/crucible/test_snapshots/macros/tests/test_macro_panic_wrong_count.1.json
@@ -1,0 +1,143 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "fire"
+              }
+            ],
+            "data": {
+              "u32": 42
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "test"
+              }
+            ],
+            "data": {
+              "u32": 42
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "fire"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/crucible/test_snapshots/macros/tests/test_macro_panic_wrong_data.1.json
+++ b/contracts/crucible/test_snapshots/macros/tests/test_macro_panic_wrong_data.1.json
@@ -1,0 +1,143 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "fire"
+              }
+            ],
+            "data": {
+              "u32": 42
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "test"
+              }
+            ],
+            "data": {
+              "u32": 42
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "fire"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}


### PR DESCRIPTION
# Description: Pre-funded Test Accounts

This PR introduces [AccountHandle](cci:2://file:///home/edohwares/Desktop/Room/drips/ceejay/crucible/contracts/crucible/src/account.rs:11:0-15:1) and [AccountBuilder](cci:2://file:///home/edohwares/Desktop/Room/drips/ceejay/crucible/contracts/crucible/src/account.rs:62:0-67:1) types to Crucible, simplifying the creation and management of pre-funded accounts in Soroban tests.

## Key Changes:
- **AccountHandle**: A new type wrapping a Soroban `Address` with high-level helpers:
  - [xlm_balance()](cci:1://file:///home/edohwares/Desktop/Room/drips/ceejay/crucible/contracts/crucible/src/account.rs:33:4-39:5): Returns the account's XLM balance in stroops.
  - [token_balance(&token)](cci:1://file:///home/edohwares/Desktop/Room/drips/ceejay/crucible/contracts/crucible/src/account.rs:41:4-44:5): Returns balance for a specific [MockToken](cci:2://file:///home/edohwares/Desktop/Room/drips/ceejay/crucible/contracts/crucible/src/token.rs:15:0-18:1).
  - Implements `Deref<Target = Address>` for use directly with contract clients.
- **AccountBuilder**: A fluent builder for creating accounts with initial funds:
  - `.name("alice")`: Registers the account in the environment by name.
  - `.fund_xlm(Stroops)`: Initial XLM funding.
  - `.fund_token(&token, amount)`: Funding with arbitrary custom tokens.
- **MockEnv Enhancements**:
  - `MockEnvBuilder::with_account(name, balance)` now correctly persists and creates funded accounts during `.build()`.
  - Added XLM token address persistence to [MockEnv](cci:2://file:///home/edohwares/Desktop/Room/drips/ceejay/crucible/contracts/crucible/src/env.rs:110:0-116:1) to ensure consistent SAC usage across accounts.
- **Ease of Use**: Updated `src/prelude.rs` to export the new types.

## Usage Example:
```rust
let env = MockEnv::builder()
    .with_account("alice", Stroops::xlm(100))
    .build();

let alice = env.account("alice");
assert_eq!(alice.xlm_balance(), 1_000_000_000);
```

Closes #4 