### PR TITLE
feat(backend): add build dedup and fixture factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4293,23 +4293,6 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
@@ -5125,7 +5108,6 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -28,6 +28,7 @@ redis = { version = "0.25", features = ["tokio-comp", "connection-manager"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 
 # Observability
 tracing = "0.1"
@@ -86,4 +87,3 @@ name = "backup"
 path = "src/bin/backup.rs"
 [features]
 testutils = ["mockall"]
-

--- a/backend/README.md
+++ b/backend/README.md
@@ -379,6 +379,27 @@ The backend runs several background workers for system health and data consisten
 - `src/jobs/` – Background job definitions (Apalis)
 - `src/services/` – Business logic and external integrations
 - `src/telemetry/` – Observability and logging setup
+
+## Build Request Deduplication
+
+The backend includes a build request deduplication service in `src/services/dedup.rs`.
+It fingerprints build submissions with SHA-256, uses Redis `SET NX EX` for fast
+in-flight duplicate suppression, persists accepted fingerprints in PostgreSQL,
+and enqueues accepted requests into a Redis list for build workers.
+
+The service exposes an Axum router for `POST /build-requests` when mounted by the
+application. Duplicate submissions return `duplicate` or `in_progress` decisions
+instead of enqueueing repeated build work.
+
+Schema is managed by `migrations/20260528010000_build_request_dedup.sql`. The
+service also exposes `BuildDedupService::ensure_schema` for isolated integration
+tests that need to provision the table directly.
+
+## Test Fixture Factory
+
+`src/test_utils/factories.rs` provides `FixtureFactory` and `TestFixture` for
+creating related users, products, orders, and sessions in tests. Existing
+domain-specific factories remain available.
 - `src/utils/` – Serialization, validation, XDR helpers
 - `src/test_utils/` – Mock traits for unit testing
 

--- a/backend/migrations/20260528010000_build_request_dedup.sql
+++ b/backend/migrations/20260528010000_build_request_dedup.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS build_request_dedup (
+    request_id UUID PRIMARY KEY,
+    fingerprint TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL,
+    request_payload JSONB NOT NULL,
+    response_payload JSONB,
+    duplicate_count BIGINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT build_request_dedup_status_check
+        CHECK (status IN ('accepted', 'completed', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_build_request_dedup_expires_at
+    ON build_request_dedup (expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_build_request_dedup_status
+    ON build_request_dedup (status);

--- a/backend/src/services/dedup.rs
+++ b/backend/src/services/dedup.rs
@@ -1,0 +1,672 @@
+//! Build request deduplication service.
+//!
+//! The service protects expensive build submission paths from repeated work by
+//! deriving a stable SHA-256 fingerprint from the request identity, acquiring a
+//! short-lived Redis lock with `SET NX EX`, and optionally persisting the
+//! deduplication record in PostgreSQL.
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use sqlx::PgPool;
+use std::sync::Arc;
+use thiserror::Error;
+use tracing::{debug, info, instrument, warn};
+use uuid::Uuid;
+
+/// Default Redis namespace for build request deduplication keys.
+pub const DEFAULT_NAMESPACE: &str = "build:dedup";
+
+/// Configuration for deduplication key retention and queueing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DedupConfig {
+    /// Redis key namespace.
+    pub namespace: String,
+    /// Completed duplicate response TTL in seconds.
+    pub result_ttl_seconds: usize,
+    /// In-flight lock TTL in seconds.
+    pub lock_ttl_seconds: usize,
+    /// Redis list used to enqueue accepted build requests.
+    pub queue_name: String,
+}
+
+impl Default for DedupConfig {
+    fn default() -> Self {
+        Self {
+            namespace: DEFAULT_NAMESPACE.to_string(),
+            result_ttl_seconds: 86_400,
+            lock_ttl_seconds: 900,
+            queue_name: "build:requests".to_string(),
+        }
+    }
+}
+
+/// A build request payload eligible for deduplication.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BuildRequest {
+    /// HTTP method or logical command name.
+    pub method: String,
+    /// HTTP path or logical build target.
+    pub path: String,
+    /// Optional caller identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requester_id: Option<String>,
+    /// Optional client supplied idempotency key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+    /// Request body.
+    #[serde(default)]
+    pub body: Value,
+}
+
+impl BuildRequest {
+    /// Creates a request value from route parts and JSON body.
+    pub fn new(method: impl Into<String>, path: impl Into<String>, body: Value) -> Self {
+        Self {
+            method: method.into(),
+            path: path.into(),
+            requester_id: None,
+            idempotency_key: None,
+            body,
+        }
+    }
+
+    /// Sets the requester identity.
+    pub fn requester_id(mut self, requester_id: impl Into<String>) -> Self {
+        self.requester_id = Some(requester_id.into());
+        self
+    }
+
+    /// Sets the client supplied idempotency key.
+    pub fn idempotency_key(mut self, idempotency_key: impl Into<String>) -> Self {
+        self.idempotency_key = Some(idempotency_key.into());
+        self
+    }
+
+    fn validate(&self) -> Result<(), DedupError> {
+        if self.method.trim().is_empty() {
+            return Err(DedupError::InvalidRequest("method is required".to_string()));
+        }
+        if self.path.trim().is_empty() {
+            return Err(DedupError::InvalidRequest("path is required".to_string()));
+        }
+        Ok(())
+    }
+}
+
+/// Deduplication state for a submitted build request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DedupStatus {
+    /// The request is new and was accepted for build processing.
+    Accepted,
+    /// The same request is already being processed.
+    InProgress,
+    /// The same request was already accepted or completed.
+    Duplicate,
+}
+
+/// Deduplication decision returned to callers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DedupDecision {
+    /// Stable request fingerprint.
+    pub fingerprint: String,
+    /// Server generated request id for the accepted or existing request.
+    pub request_id: Uuid,
+    /// Decision status.
+    pub status: DedupStatus,
+    /// Whether a cached result is available.
+    pub replayable: bool,
+}
+
+impl DedupDecision {
+    fn accepted(fingerprint: String, request_id: Uuid) -> Self {
+        Self {
+            fingerprint,
+            request_id,
+            status: DedupStatus::Accepted,
+            replayable: false,
+        }
+    }
+
+    fn duplicate(fingerprint: String, request_id: Uuid, replayable: bool) -> Self {
+        Self {
+            fingerprint,
+            request_id,
+            status: DedupStatus::Duplicate,
+            replayable,
+        }
+    }
+
+    fn in_progress(fingerprint: String, request_id: Uuid) -> Self {
+        Self {
+            fingerprint,
+            request_id,
+            status: DedupStatus::InProgress,
+            replayable: false,
+        }
+    }
+}
+
+/// Errors produced by the build request deduplication service.
+#[derive(Debug, Error)]
+pub enum DedupError {
+    /// The request did not contain enough data to be fingerprinted safely.
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
+    /// JSON serialization failed.
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    /// Redis operation failed.
+    #[error("redis error: {0}")]
+    Redis(#[from] redis::RedisError),
+    /// PostgreSQL operation failed.
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+impl IntoResponse for DedupError {
+    fn into_response(self) -> Response {
+        let status = match self {
+            Self::InvalidRequest(_) => StatusCode::BAD_REQUEST,
+            Self::Serialization(_) | Self::Redis(_) | Self::Database(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
+
+        (
+            status,
+            Json(json!({
+                "error": self.to_string(),
+                "code": status.as_u16()
+            })),
+        )
+            .into_response()
+    }
+}
+
+/// Production build request deduplicator.
+#[derive(Clone)]
+pub struct BuildDedupService {
+    db: PgPool,
+    redis: redis::Client,
+    config: DedupConfig,
+}
+
+impl BuildDedupService {
+    /// Creates a deduplication service.
+    pub fn new(db: PgPool, redis: redis::Client) -> Self {
+        Self::with_config(db, redis, DedupConfig::default())
+    }
+
+    /// Creates a deduplication service with explicit configuration.
+    pub fn with_config(db: PgPool, redis: redis::Client, config: DedupConfig) -> Self {
+        Self { db, redis, config }
+    }
+
+    /// Creates the persistence table required by this service.
+    ///
+    /// This mirrors `backend/migrations/20260528010000_build_request_dedup.sql`
+    /// for isolated integration tests. Production deployments should apply the
+    /// migration through the normal SQLx migration path.
+    pub async fn ensure_schema(pool: &PgPool) -> Result<(), DedupError> {
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS build_request_dedup (
+                request_id UUID PRIMARY KEY,
+                fingerprint TEXT NOT NULL UNIQUE,
+                status TEXT NOT NULL,
+                request_payload JSONB NOT NULL,
+                response_payload JSONB,
+                duplicate_count BIGINT NOT NULL DEFAULT 0,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                expires_at TIMESTAMPTZ NOT NULL,
+                CONSTRAINT build_request_dedup_status_check
+                    CHECK (status IN ('accepted', 'completed', 'failed'))
+            )
+            "#,
+        )
+        .execute(pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            CREATE INDEX IF NOT EXISTS idx_build_request_dedup_expires_at
+                ON build_request_dedup (expires_at)
+            "#,
+        )
+        .execute(pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            CREATE INDEX IF NOT EXISTS idx_build_request_dedup_status
+                ON build_request_dedup (status)
+            "#,
+        )
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Computes the stable request fingerprint.
+    pub fn fingerprint(request: &BuildRequest) -> Result<String, DedupError> {
+        request.validate()?;
+
+        let canonical = serde_json::to_vec(&json!({
+            "method": request.method.trim().to_ascii_uppercase(),
+            "path": request.path.trim(),
+            "requester_id": &request.requester_id,
+            "idempotency_key": &request.idempotency_key,
+            "body": &request.body,
+        }))?;
+
+        let mut hasher = Sha256::new();
+        hasher.update((canonical.len() as u64).to_be_bytes());
+        hasher.update(canonical);
+        Ok(to_hex(&hasher.finalize()))
+    }
+
+    /// Checks and registers a build request.
+    ///
+    /// Time complexity is O(n) for JSON serialization plus O(1) Redis and
+    /// indexed PostgreSQL operations. Space complexity is O(n), where n is the
+    /// serialized request size.
+    #[instrument(skip(self, request), fields(path = %request.path, method = %request.method))]
+    pub async fn check_or_register(
+        &self,
+        request: BuildRequest,
+    ) -> Result<DedupDecision, DedupError> {
+        let fingerprint = Self::fingerprint(&request)?;
+        let request_id = Uuid::new_v4();
+        let lock_key = self.lock_key(&fingerprint);
+        let result_key = self.result_key(&fingerprint);
+        let payload = serde_json::to_string(&QueuedBuildRequest {
+            request_id,
+            fingerprint: fingerprint.clone(),
+            request: request.clone(),
+            queued_at: Utc::now(),
+        })?;
+
+        let mut conn = self.redis.get_multiplexed_async_connection().await?;
+
+        if let Some(existing) = conn.get::<_, Option<String>>(&result_key).await? {
+            if let Ok(existing_id) = Uuid::parse_str(&existing) {
+                debug!(%fingerprint, %existing_id, "dedup cache hit");
+                return Ok(DedupDecision::duplicate(fingerprint, existing_id, true));
+            }
+        }
+
+        let lock_acquired: Option<String> = redis::cmd("SET")
+            .arg(&lock_key)
+            .arg(request_id.to_string())
+            .arg("NX")
+            .arg("EX")
+            .arg(self.config.lock_ttl_seconds)
+            .query_async(&mut conn)
+            .await?;
+
+        if lock_acquired.is_none() {
+            let existing_id = conn
+                .get::<_, Option<String>>(&lock_key)
+                .await?
+                .and_then(|id| Uuid::parse_str(&id).ok())
+                .unwrap_or(request_id);
+            warn!(%fingerprint, %existing_id, "duplicate build request is already in progress");
+            return Ok(DedupDecision::in_progress(fingerprint, existing_id));
+        }
+
+        let persisted = self
+            .persist_request(&fingerprint, request_id, &request)
+            .await?;
+        if persisted.request_id != request_id {
+            self.release_lock(&lock_key, request_id).await?;
+            return Ok(DedupDecision::duplicate(
+                fingerprint,
+                persisted.request_id,
+                persisted.status == "completed",
+            ));
+        }
+
+        conn.rpush::<_, _, usize>(&self.config.queue_name, payload)
+            .await?;
+        info!(%fingerprint, %request_id, "accepted unique build request");
+
+        Ok(DedupDecision::accepted(fingerprint, request_id))
+    }
+
+    /// Marks a request completed and stores the replay id in Redis.
+    #[instrument(skip(self, response))]
+    pub async fn complete(
+        &self,
+        fingerprint: &str,
+        request_id: Uuid,
+        response: Value,
+    ) -> Result<(), DedupError> {
+        sqlx::query(
+            r#"
+            UPDATE build_request_dedup
+            SET status = 'completed',
+                response_payload = $3,
+                updated_at = NOW()
+            WHERE fingerprint = $1 AND request_id = $2
+            "#,
+        )
+        .bind(fingerprint)
+        .bind(request_id)
+        .bind(response)
+        .execute(&self.db)
+        .await?;
+
+        let mut conn = self.redis.get_multiplexed_async_connection().await?;
+        conn.set_ex::<_, _, ()>(
+            self.result_key(fingerprint),
+            request_id.to_string(),
+            self.config.result_ttl_seconds as u64,
+        )
+        .await?;
+        self.release_lock(&self.lock_key(fingerprint), request_id)
+            .await?;
+        Ok(())
+    }
+
+    /// Marks a request failed and releases the in-flight lock.
+    #[instrument(skip(self))]
+    pub async fn fail(&self, fingerprint: &str, request_id: Uuid) -> Result<(), DedupError> {
+        sqlx::query(
+            r#"
+            UPDATE build_request_dedup
+            SET status = 'failed', updated_at = NOW()
+            WHERE fingerprint = $1 AND request_id = $2
+            "#,
+        )
+        .bind(fingerprint)
+        .bind(request_id)
+        .execute(&self.db)
+        .await?;
+
+        self.release_lock(&self.lock_key(fingerprint), request_id)
+            .await?;
+        Ok(())
+    }
+
+    fn lock_key(&self, fingerprint: &str) -> String {
+        format!("{}:{}:lock", self.config.namespace, fingerprint)
+    }
+
+    fn result_key(&self, fingerprint: &str) -> String {
+        format!("{}:{}:result", self.config.namespace, fingerprint)
+    }
+
+    async fn persist_request(
+        &self,
+        fingerprint: &str,
+        request_id: Uuid,
+        request: &BuildRequest,
+    ) -> Result<PersistedDedupRecord, DedupError> {
+        let expires_at =
+            Utc::now() + chrono::Duration::seconds(self.config.result_ttl_seconds as i64);
+        let payload = serde_json::to_value(request)?;
+
+        let row = sqlx::query_as::<_, PersistedDedupRecord>(
+            r#"
+            INSERT INTO build_request_dedup (
+                request_id,
+                fingerprint,
+                status,
+                request_payload,
+                expires_at
+            )
+            VALUES ($1, $2, 'accepted', $3, $4)
+            ON CONFLICT (fingerprint) DO UPDATE
+            SET duplicate_count = build_request_dedup.duplicate_count + 1,
+                updated_at = NOW()
+            RETURNING request_id, status
+            "#,
+        )
+        .bind(request_id)
+        .bind(fingerprint)
+        .bind(payload)
+        .bind(expires_at)
+        .fetch_one(&self.db)
+        .await?;
+
+        Ok(row)
+    }
+
+    async fn release_lock(&self, lock_key: &str, request_id: Uuid) -> Result<(), DedupError> {
+        let mut conn = self.redis.get_multiplexed_async_connection().await?;
+        redis::Script::new(
+            r#"
+            if redis.call("GET", KEYS[1]) == ARGV[1] then
+                return redis.call("DEL", KEYS[1])
+            end
+            return 0
+            "#,
+        )
+        .key(lock_key)
+        .arg(request_id.to_string())
+        .invoke_async::<_, i32>(&mut conn)
+        .await?;
+        Ok(())
+    }
+}
+
+/// Shared Axum state for deduplicated build request routes.
+#[derive(Clone)]
+pub struct DedupState {
+    /// Deduplication service.
+    pub service: Arc<BuildDedupService>,
+}
+
+/// Builds an Axum router for deduplicated build submissions.
+pub fn router(state: DedupState) -> Router {
+    Router::new()
+        .route("/build-requests", post(submit_build_request))
+        .with_state(state)
+}
+
+/// Axum handler for a deduplicated build request submission.
+pub async fn submit_build_request(
+    State(state): State<DedupState>,
+    Json(request): Json<BuildRequest>,
+) -> Result<Json<DedupDecision>, DedupError> {
+    state.service.check_or_register(request).await.map(Json)
+}
+
+#[derive(Debug, Serialize)]
+struct QueuedBuildRequest {
+    request_id: Uuid,
+    fingerprint: String,
+    request: BuildRequest,
+    queued_at: DateTime<Utc>,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct PersistedDedupRecord {
+    request_id: Uuid,
+    status: String,
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::postgres::PgPoolOptions;
+
+    fn sample_request() -> BuildRequest {
+        BuildRequest::new(
+            "post",
+            "/api/build",
+            json!({
+                "repo": "crucible",
+                "target": "backend",
+                "commit": "abc123"
+            }),
+        )
+        .requester_id("user-1")
+    }
+
+    #[test]
+    fn fingerprint_is_stable_for_same_request() {
+        let first = BuildDedupService::fingerprint(&sample_request()).unwrap();
+        let second = BuildDedupService::fingerprint(&sample_request()).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 64);
+    }
+
+    #[test]
+    fn fingerprint_changes_when_body_changes() {
+        let first = BuildDedupService::fingerprint(&sample_request()).unwrap();
+        let changed = BuildRequest::new(
+            "post",
+            "/api/build",
+            json!({
+                "repo": "crucible",
+                "target": "contracts",
+                "commit": "abc123"
+            }),
+        )
+        .requester_id("user-1");
+
+        let second = BuildDedupService::fingerprint(&changed).unwrap();
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn fingerprint_normalizes_method_and_path_whitespace() {
+        let first = BuildDedupService::fingerprint(&sample_request()).unwrap();
+        let second = BuildDedupService::fingerprint(&BuildRequest {
+            method: " POST ".to_string(),
+            path: " /api/build ".to_string(),
+            ..sample_request()
+        })
+        .unwrap();
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn empty_method_is_rejected() {
+        let err = BuildDedupService::fingerprint(&BuildRequest::new("", "/api/build", json!({})))
+            .unwrap_err();
+
+        assert!(matches!(err, DedupError::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn dedup_config_defaults_are_bounded() {
+        let config = DedupConfig::default();
+
+        assert_eq!(config.namespace, DEFAULT_NAMESPACE);
+        assert!(config.lock_ttl_seconds > 0);
+        assert!(config.lock_ttl_seconds < config.result_ttl_seconds);
+        assert!(!config.queue_name.is_empty());
+    }
+
+    #[test]
+    fn handler_router_can_be_constructed() {
+        let db = PgPoolOptions::new()
+            .connect_lazy("postgres://postgres:postgres@localhost/crucible_test")
+            .unwrap();
+        let redis = redis::Client::open("redis://127.0.0.1/").unwrap();
+        let state = DedupState {
+            service: Arc::new(BuildDedupService::new(db, redis)),
+        };
+
+        let _router = router(state);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL and Redis test services"]
+    async fn check_or_register_accepts_then_deduplicates_request() {
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:postgres@localhost/crucible_test".to_string());
+        let redis_url =
+            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1/".to_string());
+        let db = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await
+            .unwrap();
+        BuildDedupService::ensure_schema(&db).await.unwrap();
+
+        let redis = redis::Client::open(redis_url).unwrap();
+        let config = DedupConfig {
+            namespace: format!("{}:test:{}", DEFAULT_NAMESPACE, Uuid::new_v4()),
+            result_ttl_seconds: 60,
+            lock_ttl_seconds: 30,
+            queue_name: format!("build:requests:test:{}", Uuid::new_v4()),
+        };
+        let service = BuildDedupService::with_config(db, redis, config);
+        let request = sample_request().idempotency_key("ci-build-1");
+
+        let accepted = service.check_or_register(request.clone()).await.unwrap();
+        let duplicate = service.check_or_register(request).await.unwrap();
+
+        assert_eq!(accepted.status, DedupStatus::Accepted);
+        assert_eq!(duplicate.status, DedupStatus::InProgress);
+        assert_eq!(accepted.request_id, duplicate.request_id);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL and Redis test services"]
+    async fn complete_marks_request_replayable_for_duplicates() {
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:postgres@localhost/crucible_test".to_string());
+        let redis_url =
+            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1/".to_string());
+        let db = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await
+            .unwrap();
+        BuildDedupService::ensure_schema(&db).await.unwrap();
+
+        let redis = redis::Client::open(redis_url).unwrap();
+        let config = DedupConfig {
+            namespace: format!("{}:test:{}", DEFAULT_NAMESPACE, Uuid::new_v4()),
+            result_ttl_seconds: 60,
+            lock_ttl_seconds: 30,
+            queue_name: format!("build:requests:test:{}", Uuid::new_v4()),
+        };
+        let service = BuildDedupService::with_config(db, redis, config);
+        let request = sample_request().idempotency_key("ci-build-2");
+
+        let accepted = service.check_or_register(request.clone()).await.unwrap();
+        service
+            .complete(
+                &accepted.fingerprint,
+                accepted.request_id,
+                json!({ "build_id": "build-1" }),
+            )
+            .await
+            .unwrap();
+        let duplicate = service.check_or_register(request).await.unwrap();
+
+        assert_eq!(duplicate.status, DedupStatus::Duplicate);
+        assert_eq!(duplicate.request_id, accepted.request_id);
+        assert!(duplicate.replayable);
+    }
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod log_alerts;
+pub mod dedup;
 pub mod alerts;
 pub mod error_recovery;
 pub mod feature_flags;

--- a/backend/src/test_utils/factories.rs
+++ b/backend/src/test_utils/factories.rs
@@ -34,3 +34,247 @@ pub use user::{UserFactory, build as build_user, create as create_user, create_w
 pub use order::{OrderFactory, build as build_order, create as create_order, create_with as create_order_with, create_many as create_orders, create_many_with as create_orders_with, create_for_user as create_order_for_user, create_with_items as create_order_with_items, OrderStatus, PaymentMethod, OrderItem};
 pub use product::{ProductFactory, build as build_product, create as create_product, create_with as create_product_with, create_many as create_products, create_many_with as create_products_with, ProductCategory, Availability};
 pub use session::{SessionFactory, build as build_session, create as create_session, create_with as create_session_with, create_many as create_sessions, create_many_with as create_sessions_with, create_for_user as create_session_for_user, create_many_for_user as create_sessions_for_user, SessionStatus, SessionType};
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+/// Complete domain fixture used by backend tests.
+#[derive(Debug, Clone)]
+pub struct TestFixture {
+    /// Users in the fixture.
+    pub users: Vec<user::User>,
+    /// Products in the fixture.
+    pub products: Vec<product::Product>,
+    /// Orders linked to fixture users.
+    pub orders: Vec<order::Order>,
+    /// Sessions linked to fixture users.
+    pub sessions: Vec<session::Session>,
+    /// Stable creation timestamp applied to all generated entities.
+    pub created_at: DateTime<Utc>,
+}
+
+impl TestFixture {
+    /// Returns the first user id, if a user exists.
+    pub fn primary_user_id(&self) -> Option<Uuid> {
+        self.users.first().map(|user| user.id)
+    }
+}
+
+/// Builder for cohesive backend test fixtures.
+///
+/// The factory composes the existing domain-specific factories while keeping
+/// relationships valid: orders and sessions always reference generated users.
+/// Complexity is O(u + p + u * (o + s)) time and space, where `u` is user
+/// count, `p` is product count, `o` is orders per user, and `s` is sessions per
+/// user.
+#[derive(Debug, Clone)]
+pub struct FixtureFactory {
+    user_count: usize,
+    product_count: usize,
+    orders_per_user: usize,
+    sessions_per_user: usize,
+    created_at: DateTime<Utc>,
+}
+
+impl Default for FixtureFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FixtureFactory {
+    /// Creates a factory with a minimal but useful default fixture shape.
+    pub fn new() -> Self {
+        Self {
+            user_count: 1,
+            product_count: 1,
+            orders_per_user: 1,
+            sessions_per_user: 1,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Sets how many users to create.
+    pub fn users(mut self, count: usize) -> Self {
+        self.user_count = count;
+        self
+    }
+
+    /// Sets how many products to create.
+    pub fn products(mut self, count: usize) -> Self {
+        self.product_count = count;
+        self
+    }
+
+    /// Sets how many orders to create for each generated user.
+    pub fn orders_per_user(mut self, count: usize) -> Self {
+        self.orders_per_user = count;
+        self
+    }
+
+    /// Sets how many sessions to create for each generated user.
+    pub fn sessions_per_user(mut self, count: usize) -> Self {
+        self.sessions_per_user = count;
+        self
+    }
+
+    /// Sets a stable timestamp for generated entities.
+    pub fn created_at(mut self, created_at: DateTime<Utc>) -> Self {
+        self.created_at = created_at;
+        self
+    }
+
+    /// Builds the fixture.
+    pub fn build(self) -> TestFixture {
+        let users = self.build_users();
+        let products = self.build_products();
+        let orders = self.build_orders(&users, &products);
+        let sessions = self.build_sessions(&users);
+
+        TestFixture {
+            users,
+            products,
+            orders,
+            sessions,
+            created_at: self.created_at,
+        }
+    }
+
+    fn build_users(&self) -> Vec<user::User> {
+        (0..self.user_count)
+            .map(|idx| {
+                user::build()
+                    .email(format!("fixture-user-{idx}@example.com"))
+                    .username(format!("fixture_user_{idx}"))
+                    .created_at(self.created_at)
+                    .finish()
+            })
+            .collect()
+    }
+
+    fn build_products(&self) -> Vec<product::Product> {
+        (0..self.product_count)
+            .map(|idx| {
+                product::build()
+                    .name(format!("Fixture Product {idx}"))
+                    .sku(format!("FIXTURE-SKU-{idx}"))
+                    .created_at(self.created_at)
+                    .updated_at(self.created_at)
+                    .finish()
+            })
+            .collect()
+    }
+
+    fn build_orders(
+        &self,
+        users: &[user::User],
+        products: &[product::Product],
+    ) -> Vec<order::Order> {
+        if products.is_empty() {
+            return Vec::new();
+        }
+
+        users
+            .iter()
+            .flat_map(|user| {
+                (0..self.orders_per_user).map(move |idx| {
+                    let product = &products[idx % products.len()];
+                    let item = order::OrderItem::new(
+                        product.id,
+                        product.name.clone(),
+                        1,
+                        product.price_cents,
+                    );
+
+                    order::build()
+                        .user_id(user.id)
+                        .add_item(item)
+                        .created_at(self.created_at)
+                        .updated_at(self.created_at)
+                        .finish()
+                })
+            })
+            .collect()
+    }
+
+    fn build_sessions(&self, users: &[user::User]) -> Vec<session::Session> {
+        users
+            .iter()
+            .flat_map(|user| {
+                (0..self.sessions_per_user).map(move |_| {
+                    session::build()
+                        .user_id(user.id)
+                        .created_at(self.created_at)
+                        .last_used_at(self.created_at)
+                        .finish()
+                })
+            })
+            .collect()
+    }
+}
+
+/// Creates the default cohesive test fixture.
+pub fn create_fixture() -> TestFixture {
+    FixtureFactory::new().build()
+}
+
+/// Returns a builder for cohesive backend test fixtures.
+pub fn build_fixture() -> FixtureFactory {
+    FixtureFactory::new()
+}
+
+#[cfg(test)]
+mod fixture_factory_tests {
+    use super::*;
+
+    #[test]
+    fn default_fixture_has_related_domain_objects() {
+        let fixture = create_fixture();
+
+        assert_eq!(fixture.users.len(), 1);
+        assert_eq!(fixture.products.len(), 1);
+        assert_eq!(fixture.orders.len(), 1);
+        assert_eq!(fixture.sessions.len(), 1);
+        assert_eq!(fixture.orders[0].user_id, fixture.users[0].id);
+        assert_eq!(fixture.sessions[0].user_id, fixture.users[0].id);
+    }
+
+    #[test]
+    fn fixture_counts_scale_by_user_relationships() {
+        let fixture = build_fixture()
+            .users(3)
+            .products(2)
+            .orders_per_user(2)
+            .sessions_per_user(4)
+            .build();
+
+        assert_eq!(fixture.users.len(), 3);
+        assert_eq!(fixture.products.len(), 2);
+        assert_eq!(fixture.orders.len(), 6);
+        assert_eq!(fixture.sessions.len(), 12);
+    }
+
+    #[test]
+    fn no_products_means_no_orders() {
+        let fixture = build_fixture()
+            .users(2)
+            .products(0)
+            .orders_per_user(3)
+            .build();
+
+        assert_eq!(fixture.orders.len(), 0);
+        assert_eq!(fixture.sessions.len(), 2);
+    }
+
+    #[test]
+    fn fixed_timestamp_is_applied() {
+        let now = Utc::now();
+        let fixture = build_fixture().created_at(now).build();
+
+        assert_eq!(fixture.created_at, now);
+        assert_eq!(fixture.users[0].created_at, now);
+        assert_eq!(fixture.products[0].created_at, now);
+        assert_eq!(fixture.orders[0].created_at, now);
+        assert_eq!(fixture.sessions[0].created_at, now);
+    }
+}


### PR DESCRIPTION
Closes #189 
Closes #207 

# PR Description

Fixes #207 and #189 by adding a backend build request deduplication service and a cohesive test fixture factory. Build requests now get a stable SHA-256 fingerprint, use Redis `SET NX EX` to prevent duplicate in-flight work, persist request state in PostgreSQL with a unique fingerprint constraint, and enqueue accepted requests for downstream build workers. The fixture factory creates related users, products, orders, and sessions so backend tests can set up consistent domain data with less boilerplate.

# Changed

- #207: Added `backend/src/services/dedup.rs` with Axum handler support, Redis locking, PostgreSQL persistence, queue enqueueing, tracing, custom errors, and tests.
- #207: Added `backend/migrations/20260528010000_build_request_dedup.sql` for the deduplication table and indexes.
- #189: Added `FixtureFactory` and `TestFixture` in `backend/src/test_utils/factories.rs`.
- #207/#189: Updated backend docs and dependency metadata.
- Fixed existing `Cargo.lock` parse blockers needed for Cargo verification.