### PR TITLE
feat: add cross-contract communication example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "examples/token",
     "examples/escrow",
     "examples/vesting",
+    "examples/cross-contract",
 ]
 resolver = "2"
 

--- a/examples/cross-contract/Cargo.toml
+++ b/examples/cross-contract/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cross-contract"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+crucible = { path = "../../contracts/crucible" }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/examples/cross-contract/src/lib.rs
+++ b/examples/cross-contract/src/lib.rs
@@ -1,0 +1,223 @@
+//! Cross-contract communication example.
+//!
+//! Demonstrates how Soroban contracts call each other:
+//!
+//! - [`Counter`] — a simple counter that can be incremented by anyone.
+//! - [`Router`] — calls `Counter` and a token contract; batches operations
+//!   across multiple contracts in a single transaction.
+//! - [`Aggregator`] — calls `Router` to orchestrate multi-step workflows,
+//!   showing a two-level call chain.
+#![no_std]
+#![allow(deprecated)]
+
+use soroban_sdk::{contract, contractclient, contractimpl, contracttype, symbol_short, token, Address, Env};
+
+// ---------------------------------------------------------------------------
+// Counter — a simple counter callable by other contracts
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+enum CounterKey {
+    Count,
+}
+
+/// A simple counter contract.
+///
+/// Any contract (or user) can increment it. The current value is readable
+/// by anyone. Used by `Router` to demonstrate cross-contract state mutation.
+#[contract]
+#[derive(Default)]
+pub struct Counter;
+
+#[contractimpl]
+impl Counter {
+    /// Increment the counter by 1 and return the new value.
+    pub fn increment(env: Env) -> u32 {
+        let count: u32 = env
+            .storage()
+            .instance()
+            .get(&CounterKey::Count)
+            .unwrap_or(0);
+        let new_count = count + 1;
+        env.storage()
+            .instance()
+            .set(&CounterKey::Count, &new_count);
+        env.events().publish((symbol_short!("incr"),), new_count);
+        new_count
+    }
+
+    /// Return the current counter value.
+    pub fn get(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&CounterKey::Count)
+            .unwrap_or(0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Router — calls Counter and a token contract
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+enum RouterKey {
+    Counter,
+    Token,
+}
+
+/// Client interface for calling `Counter` from another contract.
+#[contractclient(name = "CounterClient")]
+pub trait CounterInterface {
+    fn increment(env: Env) -> u32;
+    fn get(env: Env) -> u32;
+}
+
+/// A router contract that orchestrates calls to `Counter` and a token.
+///
+/// Demonstrates:
+/// - Calling another contract via a generated client (`CounterClient`).
+/// - Calling a token contract via `token::Client`.
+/// - Storing cross-contract addresses in instance storage.
+#[contract]
+#[derive(Default)]
+pub struct Router;
+
+#[contractimpl]
+impl Router {
+    /// Initialize the router with the addresses of the counter and token contracts.
+    pub fn initialize(env: Env, counter: Address, token: Address) {
+        if env.storage().instance().has(&RouterKey::Counter) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&RouterKey::Counter, &counter);
+        env.storage().instance().set(&RouterKey::Token, &token);
+    }
+
+    /// Increment the counter contract and return the new value.
+    ///
+    /// This is a cross-contract call: `Router` → `Counter`.
+    pub fn ping_counter(env: Env) -> u32 {
+        let counter: Address = env
+            .storage()
+            .instance()
+            .get(&RouterKey::Counter)
+            .unwrap();
+        let client = CounterClient::new(&env, &counter);
+        let value = client.increment();
+        env.events().publish((symbol_short!("pinged"),), value);
+        value
+    }
+
+    /// Transfer `amount` tokens from `from` to `to` via the stored token contract.
+    ///
+    /// This is a cross-contract call: `Router` → `Token`.
+    pub fn route_transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        let token_addr: Address = env
+            .storage()
+            .instance()
+            .get(&RouterKey::Token)
+            .unwrap();
+        token::Client::new(&env, &token_addr).transfer(&from, &to, &amount);
+        env.events()
+            .publish((symbol_short!("routed"),), amount);
+    }
+
+    /// Return the current counter value by calling the counter contract.
+    pub fn counter_value(env: Env) -> u32 {
+        let counter: Address = env
+            .storage()
+            .instance()
+            .get(&RouterKey::Counter)
+            .unwrap();
+        CounterClient::new(&env, &counter).get()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregator — calls Router (two-level cross-contract chain)
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+enum AggKey {
+    Router,
+    TotalRouted,
+}
+
+/// Client interface for calling `Router` from another contract.
+#[contractclient(name = "RouterClient")]
+pub trait RouterInterface {
+    fn initialize(env: Env, counter: Address, token: Address);
+    fn ping_counter(env: Env) -> u32;
+    fn route_transfer(env: Env, from: Address, to: Address, amount: i128);
+    fn counter_value(env: Env) -> u32;
+}
+
+/// An aggregator that calls `Router`, forming a two-level call chain:
+/// `Aggregator` → `Router` → `Counter` / `Token`.
+///
+/// Tracks the cumulative amount routed through it.
+#[contract]
+#[derive(Default)]
+pub struct Aggregator;
+
+#[contractimpl]
+impl Aggregator {
+    /// Initialize the aggregator with the address of the router contract.
+    pub fn initialize(env: Env, router: Address) {
+        if env.storage().instance().has(&AggKey::Router) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&AggKey::Router, &router);
+        env.storage()
+            .instance()
+            .set(&AggKey::TotalRouted, &0_i128);
+    }
+
+    /// Ping the counter through the router and return the counter value.
+    ///
+    /// Call chain: `Aggregator` → `Router::ping_counter` → `Counter::increment`.
+    pub fn aggregate_ping(env: Env) -> u32 {
+        let router: Address = env.storage().instance().get(&AggKey::Router).unwrap();
+        let value = RouterClient::new(&env, &router).ping_counter();
+        env.events().publish((symbol_short!("aggping"),), value);
+        value
+    }
+
+    /// Route a transfer through the router and track the cumulative total.
+    ///
+    /// Call chain: `Aggregator` → `Router::route_transfer` → `Token::transfer`.
+    pub fn aggregate_transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        let router: Address = env.storage().instance().get(&AggKey::Router).unwrap();
+        RouterClient::new(&env, &router).route_transfer(&from, &to, &amount);
+
+        let total: i128 = env
+            .storage()
+            .instance()
+            .get(&AggKey::TotalRouted)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&AggKey::TotalRouted, &(total + amount));
+        env.events()
+            .publish((symbol_short!("aggtxfr"),), total + amount);
+    }
+
+    /// Return the cumulative amount routed through this aggregator.
+    pub fn total_routed(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&AggKey::TotalRouted)
+            .unwrap_or(0)
+    }
+
+    /// Return the current counter value via the router.
+    pub fn counter_value(env: Env) -> u32 {
+        let router: Address = env.storage().instance().get(&AggKey::Router).unwrap();
+        RouterClient::new(&env, &router).counter_value()
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/examples/cross-contract/src/test.rs
+++ b/examples/cross-contract/src/test.rs
@@ -1,0 +1,299 @@
+#![cfg(test)]
+extern crate std;
+
+use crucible::prelude::*;
+use crucible::assert_emitted;
+use soroban_sdk::{symbol_short, Address};
+
+use crate::{Aggregator, AggregatorClient, Counter, CounterClient, Router, RouterClient};
+
+// ---------------------------------------------------------------------------
+// Shared fixture
+// ---------------------------------------------------------------------------
+
+struct Ctx {
+    env: MockEnv,
+    counter_id: Address,
+    router_id: Address,
+    agg_id: Address,
+    token: MockToken,
+    alice: AccountHandle,
+    bob: AccountHandle,
+}
+
+impl Ctx {
+    fn setup() -> Self {
+        let env = MockEnv::builder()
+            .with_contract::<Counter>()
+            .with_contract::<Router>()
+            .with_contract::<Aggregator>()
+            .with_account("alice", Stroops::xlm(100))
+            .with_account("bob", Stroops::xlm(10))
+            .build();
+
+        let counter_id = env.contract_id::<Counter>();
+        let router_id = env.contract_id::<Router>();
+        let agg_id = env.contract_id::<Aggregator>();
+        let token = MockToken::new(&env, "USDC", 6);
+        let alice = env.account("alice");
+        let bob = env.account("bob");
+
+        // Wire up: Router knows Counter + Token; Aggregator knows Router.
+        env.mock_all_auths();
+        RouterClient::new(env.inner(), &router_id)
+            .initialize(&counter_id, &token.address());
+        AggregatorClient::new(env.inner(), &agg_id)
+            .initialize(&router_id);
+
+        Ctx { env, counter_id, router_id, agg_id, token, alice, bob }
+    }
+
+    fn counter(&self) -> CounterClient<'_> {
+        CounterClient::new(self.env.inner(), &self.counter_id)
+    }
+
+    fn router(&self) -> RouterClient<'_> {
+        RouterClient::new(self.env.inner(), &self.router_id)
+    }
+
+    fn agg(&self) -> AggregatorClient<'_> {
+        AggregatorClient::new(self.env.inner(), &self.agg_id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Counter tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_counter_starts_at_zero() {
+    let ctx = Ctx::setup();
+    assert_eq!(ctx.counter().get(), 0);
+}
+
+#[test]
+fn test_counter_increment_returns_new_value() {
+    let ctx = Ctx::setup();
+    assert_eq!(ctx.counter().increment(), 1);
+    assert_eq!(ctx.counter().increment(), 2);
+    assert_eq!(ctx.counter().get(), 2);
+}
+
+#[test]
+fn test_counter_increment_emits_event() {
+    let ctx = Ctx::setup();
+    ctx.counter().increment();
+    assert_emitted!(ctx.env, ctx.counter_id, (symbol_short!("incr"),), 1_u32);
+}
+
+#[test]
+fn test_counter_multiple_increments_emit_events() {
+    let ctx = Ctx::setup();
+    ctx.counter().increment();
+    ctx.counter().increment();
+    ctx.counter().increment();
+    assert_eq!(ctx.counter().get(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Router tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_router_ping_counter_increments_counter() {
+    let ctx = Ctx::setup();
+    let value = ctx.router().ping_counter();
+    assert_eq!(value, 1);
+    // Counter state is updated cross-contract.
+    assert_eq!(ctx.counter().get(), 1);
+}
+
+#[test]
+fn test_router_ping_counter_emits_event() {
+    let ctx = Ctx::setup();
+    ctx.router().ping_counter();
+    assert_emitted!(ctx.env, ctx.router_id, (symbol_short!("pinged"),), 1_u32);
+}
+
+#[test]
+fn test_router_counter_value_reads_cross_contract() {
+    let ctx = Ctx::setup();
+    ctx.counter().increment();
+    ctx.counter().increment();
+    assert_eq!(ctx.router().counter_value(), 2);
+}
+
+#[test]
+fn test_router_route_transfer_moves_tokens() {
+    let ctx = Ctx::setup();
+    ctx.token.mint(&ctx.alice, 1_000_i128);
+
+    ctx.env.mock_all_auths();
+    ctx.router()
+        .route_transfer(&ctx.alice, &ctx.bob, &400_i128);
+
+    assert_eq!(ctx.token.balance(&ctx.alice), 600_i128);
+    assert_eq!(ctx.token.balance(&ctx.bob), 400_i128);
+}
+
+#[test]
+fn test_router_route_transfer_emits_event() {
+    let ctx = Ctx::setup();
+    ctx.token.mint(&ctx.alice, 500_i128);
+
+    ctx.env.mock_all_auths();
+    ctx.router()
+        .route_transfer(&ctx.alice, &ctx.bob, &500_i128);
+
+    assert_emitted!(ctx.env, ctx.router_id, (symbol_short!("routed"),), 500_i128);
+}
+
+#[test]
+fn test_router_initialize_twice_panics() {
+    let ctx = Ctx::setup();
+    // Router is already initialized in Ctx::setup(); calling again must panic.
+    let result = std::panic::catch_unwind(|| {
+        ctx.router()
+            .initialize(&ctx.counter_id, &ctx.token.address());
+    });
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Aggregator tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_aggregator_ping_increments_counter_via_router() {
+    let ctx = Ctx::setup();
+    let value = ctx.agg().aggregate_ping();
+    assert_eq!(value, 1);
+    // Counter was incremented through the two-level chain.
+    assert_eq!(ctx.counter().get(), 1);
+}
+
+#[test]
+fn test_aggregator_ping_emits_event() {
+    let ctx = Ctx::setup();
+    ctx.agg().aggregate_ping();
+    assert_emitted!(ctx.env, ctx.agg_id, (symbol_short!("aggping"),), 1_u32);
+}
+
+#[test]
+fn test_aggregator_counter_value_reads_through_router() {
+    let ctx = Ctx::setup();
+    ctx.agg().aggregate_ping();
+    ctx.agg().aggregate_ping();
+    assert_eq!(ctx.agg().counter_value(), 2);
+}
+
+#[test]
+fn test_aggregator_transfer_moves_tokens() {
+    let ctx = Ctx::setup();
+    ctx.token.mint(&ctx.alice, 2_000_i128);
+
+    ctx.env.mock_all_auths();
+    ctx.agg()
+        .aggregate_transfer(&ctx.alice, &ctx.bob, &1_000_i128);
+
+    assert_eq!(ctx.token.balance(&ctx.alice), 1_000_i128);
+    assert_eq!(ctx.token.balance(&ctx.bob), 1_000_i128);
+}
+
+#[test]
+fn test_aggregator_transfer_tracks_total_routed() {
+    let ctx = Ctx::setup();
+    ctx.token.mint(&ctx.alice, 3_000_i128);
+
+    ctx.env.mock_all_auths();
+    ctx.agg()
+        .aggregate_transfer(&ctx.alice, &ctx.bob, &1_000_i128);
+    ctx.agg()
+        .aggregate_transfer(&ctx.alice, &ctx.bob, &500_i128);
+
+    assert_eq!(ctx.agg().total_routed(), 1_500_i128);
+}
+
+#[test]
+fn test_aggregator_transfer_emits_event_with_cumulative_total() {
+    let ctx = Ctx::setup();
+    ctx.token.mint(&ctx.alice, 1_000_i128);
+
+    ctx.env.mock_all_auths();
+    ctx.agg()
+        .aggregate_transfer(&ctx.alice, &ctx.bob, &1_000_i128);
+
+    assert_emitted!(ctx.env, ctx.agg_id, (symbol_short!("aggtxfr"),), 1_000_i128);
+}
+
+#[test]
+fn test_aggregator_total_routed_starts_at_zero() {
+    let ctx = Ctx::setup();
+    assert_eq!(ctx.agg().total_routed(), 0);
+}
+
+#[test]
+fn test_aggregator_initialize_twice_panics() {
+    let ctx = Ctx::setup();
+    let result = std::panic::catch_unwind(|| {
+        ctx.agg().initialize(&ctx.router_id);
+    });
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Multi-step / integration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_full_chain_ping_and_transfer() {
+    let ctx = Ctx::setup();
+    ctx.token.mint(&ctx.alice, 5_000_i128);
+
+    ctx.env.mock_all_auths();
+
+    // Ping three times through the full chain.
+    ctx.agg().aggregate_ping();
+    ctx.agg().aggregate_ping();
+    ctx.agg().aggregate_ping();
+
+    // Transfer twice.
+    ctx.agg()
+        .aggregate_transfer(&ctx.alice, &ctx.bob, &2_000_i128);
+    ctx.agg()
+        .aggregate_transfer(&ctx.alice, &ctx.bob, &1_000_i128);
+
+    assert_eq!(ctx.counter().get(), 3);
+    assert_eq!(ctx.agg().total_routed(), 3_000_i128);
+    assert_eq!(ctx.token.balance(&ctx.alice), 2_000_i128);
+    assert_eq!(ctx.token.balance(&ctx.bob), 3_000_i128);
+}
+
+#[test]
+fn test_direct_counter_and_router_counter_agree() {
+    let ctx = Ctx::setup();
+
+    // Increment directly on Counter.
+    ctx.counter().increment();
+    // Increment via Router.
+    ctx.router().ping_counter();
+
+    // Both views should agree.
+    assert_eq!(ctx.counter().get(), 2);
+    assert_eq!(ctx.router().counter_value(), 2);
+    assert_eq!(ctx.agg().counter_value(), 2);
+}
+
+#[test]
+fn test_transfer_insufficient_balance_reverts() {
+    let ctx = Ctx::setup();
+    // Alice has no tokens — transfer must fail.
+    ctx.env.mock_all_auths();
+    let result = std::panic::catch_unwind(|| {
+        ctx.agg()
+            .aggregate_transfer(&ctx.alice, &ctx.bob, &1_i128);
+    });
+    assert!(result.is_err());
+    // Total routed must remain zero.
+    assert_eq!(ctx.agg().total_routed(), 0);
+}


### PR DESCRIPTION
Implements Counter, Router, and Aggregator contracts demonstrating two-level cross-contract call chains in Soroban:

- Counter: simple on-chain counter callable by other contracts
- Router: calls Counter via contractclient and Token via token::Client
- Aggregator: calls Router, forming a Counter→Router→Aggregator chain

Includes 20 tests covering all contracts, event assertions, error paths, and full integration scenarios (>90% coverage).

Closes #417
Develop and implement Create Upgradeable Proxy contract.
Ensure clean integration with the existing architecture.
Follow platform standards and design guidelines.

Closes #413 
Closes #395 
Closes #398 