### PR TITLE
feat(contracts): add prediction market contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "crucible-example-prediction-market"
+version = "0.1.0"
+dependencies = [
+ "crucible",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "crucible-example-token"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "examples/token",
     "examples/escrow",
     "examples/vesting",
+    "examples/prediction-market",
 ]
 resolver = "2"
 

--- a/examples/prediction-market/Cargo.toml
+++ b/examples/prediction-market/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "crucible-example-prediction-market"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+crucible = { path = "../../contracts/crucible" }

--- a/examples/prediction-market/src/lib.rs
+++ b/examples/prediction-market/src/lib.rs
@@ -1,0 +1,224 @@
+#![no_std]
+#![allow(deprecated)]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
+
+/// Binary outcome supported by the prediction market.
+#[contracttype]
+#[derive(Clone, PartialEq, Debug)]
+pub enum Outcome {
+    Yes,
+    No,
+}
+
+/// Lifecycle state for a market.
+#[contracttype]
+#[derive(Clone, PartialEq, Debug)]
+pub enum MarketStatus {
+    Open,
+    Resolved,
+}
+
+/// Market-level state stored under a single instance key.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MarketState {
+    pub admin: Address,
+    pub token: Address,
+    pub close_time: u64,
+    pub status: MarketStatus,
+    pub winning_outcome: Outcome,
+    pub yes_total: i128,
+    pub no_total: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+struct PositionKey {
+    trader: Address,
+    outcome: Outcome,
+}
+
+#[contracttype]
+enum DataKey {
+    State,
+    Position(PositionKey),
+}
+
+/// A minimal binary prediction market with escrowed collateral.
+///
+/// Traders buy YES or NO exposure before `close_time`. After the market closes,
+/// the admin resolves the winning outcome and winners claim a proportional share
+/// of the full collateral pool.
+#[contract]
+#[derive(Default)]
+pub struct PredictionMarket;
+
+#[contractimpl]
+impl PredictionMarket {
+    /// Initialize the market.
+    ///
+    /// `admin` acts as the resolver/oracle, `token` is the collateral asset,
+    /// and `close_time` is the earliest timestamp at which resolution is valid.
+    pub fn initialize(env: Env, admin: Address, token: Address, close_time: u64) {
+        if env.storage().instance().has(&DataKey::State) {
+            panic!("market already initialized");
+        }
+        if close_time <= env.ledger().timestamp() {
+            panic!("close time must be in the future");
+        }
+        admin.require_auth();
+
+        env.storage().instance().set(
+            &DataKey::State,
+            &MarketState {
+                admin,
+                token,
+                close_time,
+                status: MarketStatus::Open,
+                winning_outcome: Outcome::No,
+                yes_total: 0,
+                no_total: 0,
+            },
+        );
+        env.events().publish((symbol_short!("init"),), close_time);
+    }
+
+    /// Buy exposure to an outcome before the market closes.
+    ///
+    /// The caller's collateral is transferred into the contract and their
+    /// position for the selected outcome is increased by `amount`.
+    pub fn buy(env: Env, trader: Address, outcome: Outcome, amount: i128) {
+        let mut state = Self::require_state(&env);
+        if state.status != MarketStatus::Open {
+            panic!("market is not open");
+        }
+        if env.ledger().timestamp() >= state.close_time {
+            panic!("market is closed");
+        }
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+        trader.require_auth();
+
+        token::Client::new(&env, &state.token).transfer(
+            &trader,
+            env.current_contract_address(),
+            &amount,
+        );
+
+        let key = DataKey::Position(PositionKey {
+            trader: trader.clone(),
+            outcome: outcome.clone(),
+        });
+        let position: i128 = env.storage().instance().get(&key).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&key, &Self::checked_add(position, amount));
+
+        match outcome {
+            Outcome::Yes => state.yes_total = Self::checked_add(state.yes_total, amount),
+            Outcome::No => state.no_total = Self::checked_add(state.no_total, amount),
+        }
+        env.storage().instance().set(&DataKey::State, &state);
+        env.events().publish((symbol_short!("buy"), trader), amount);
+    }
+
+    /// Resolve the market after close. Admin only.
+    pub fn resolve(env: Env, admin: Address, winning_outcome: Outcome) {
+        let mut state = Self::require_state(&env);
+        if state.status != MarketStatus::Open {
+            panic!("market already resolved");
+        }
+        if admin != state.admin {
+            panic!("only the admin can resolve");
+        }
+        if env.ledger().timestamp() < state.close_time {
+            panic!("market is still open");
+        }
+        admin.require_auth();
+
+        state.status = MarketStatus::Resolved;
+        state.winning_outcome = winning_outcome.clone();
+        env.storage().instance().set(&DataKey::State, &state);
+        env.events()
+            .publish((symbol_short!("resolved"),), winning_outcome);
+    }
+
+    /// Claim the caller's proportional payout after resolution.
+    pub fn claim(env: Env, trader: Address) -> i128 {
+        let state = Self::require_state(&env);
+        if state.status != MarketStatus::Resolved {
+            panic!("market is not resolved");
+        }
+        trader.require_auth();
+
+        let key = DataKey::Position(PositionKey {
+            trader: trader.clone(),
+            outcome: state.winning_outcome.clone(),
+        });
+        let position: i128 = env.storage().instance().get(&key).unwrap_or(0);
+        if position <= 0 {
+            panic!("no winning position");
+        }
+
+        let payout = Self::payout(&state, position);
+        env.storage().instance().set(&key, &0_i128);
+        token::Client::new(&env, &state.token).transfer(
+            &env.current_contract_address(),
+            &trader,
+            &payout,
+        );
+        env.events()
+            .publish((symbol_short!("claim"), trader), payout);
+        payout
+    }
+
+    /// Return the complete market state.
+    pub fn get_state(env: Env) -> MarketState {
+        Self::require_state(&env)
+    }
+
+    /// Return a trader's position for one outcome.
+    pub fn position(env: Env, trader: Address, outcome: Outcome) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::Position(PositionKey { trader, outcome }))
+            .unwrap_or(0)
+    }
+
+    /// Return total collateral escrowed across both sides.
+    pub fn pool_total(env: Env) -> i128 {
+        let state = Self::require_state(&env);
+        Self::checked_add(state.yes_total, state.no_total)
+    }
+
+    fn require_state(env: &Env) -> MarketState {
+        env.storage()
+            .instance()
+            .get(&DataKey::State)
+            .unwrap_or_else(|| panic!("market is not initialized"))
+    }
+
+    fn payout(state: &MarketState, position: i128) -> i128 {
+        let winning_total = match state.winning_outcome {
+            Outcome::Yes => state.yes_total,
+            Outcome::No => state.no_total,
+        };
+        if winning_total <= 0 {
+            panic!("no winning liquidity");
+        }
+        let pool = Self::checked_add(state.yes_total, state.no_total);
+        position
+            .checked_mul(pool)
+            .unwrap_or_else(|| panic!("payout overflow"))
+            / winning_total
+    }
+
+    fn checked_add(left: i128, right: i128) -> i128 {
+        left.checked_add(right)
+            .unwrap_or_else(|| panic!("amount overflow"))
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/examples/prediction-market/src/test.rs
+++ b/examples/prediction-market/src/test.rs
@@ -1,0 +1,300 @@
+#![cfg(test)]
+extern crate std;
+
+use crucible::prelude::*;
+use crucible::{assert_emitted, assert_reverts};
+use soroban_sdk::{symbol_short, Address};
+
+use crate::{MarketStatus, Outcome, PredictionMarket, PredictionMarketClient};
+
+const BASE_TIME: u64 = 1_000_000;
+const CLOSE_DELAY: u64 = 86_400;
+const ALICE_STAKE: i128 = 600_000;
+const BOB_STAKE: i128 = 400_000;
+const CAROL_STAKE: i128 = 500_000;
+
+struct Ctx {
+    pub env: MockEnv,
+    pub id: Address,
+    pub admin: AccountHandle,
+    pub alice: AccountHandle,
+    pub bob: AccountHandle,
+    pub carol: AccountHandle,
+    pub token: MockToken,
+}
+
+impl Ctx {
+    fn setup() -> Self {
+        let env = MockEnv::builder()
+            .at_timestamp(BASE_TIME)
+            .with_contract::<PredictionMarket>()
+            .with_account("admin", Stroops::xlm(100))
+            .with_account("alice", Stroops::xlm(10))
+            .with_account("bob", Stroops::xlm(10))
+            .with_account("carol", Stroops::xlm(10))
+            .build();
+
+        let id = env.contract_id::<PredictionMarket>();
+        let admin = env.account("admin");
+        let alice = env.account("alice");
+        let bob = env.account("bob");
+        let carol = env.account("carol");
+
+        let token = MockToken::new(&env, "USDC", 6);
+        token.mint(&alice, 2_000_000);
+        token.mint(&bob, 2_000_000);
+        token.mint(&carol, 2_000_000);
+
+        Ctx {
+            env,
+            id,
+            admin,
+            alice,
+            bob,
+            carol,
+            token,
+        }
+    }
+
+    fn client(&self) -> PredictionMarketClient<'_> {
+        PredictionMarketClient::new(self.env.inner(), &self.id)
+    }
+
+    fn initialize(&self) {
+        self.env.mock_all_auths();
+        self.client().initialize(
+            &self.admin,
+            &self.token.address(),
+            &(BASE_TIME + CLOSE_DELAY),
+        );
+    }
+
+    fn fund_market(&self) {
+        self.initialize();
+        self.client().buy(&self.alice, &Outcome::Yes, &ALICE_STAKE);
+        self.client().buy(&self.bob, &Outcome::Yes, &BOB_STAKE);
+        self.client().buy(&self.carol, &Outcome::No, &CAROL_STAKE);
+    }
+
+    fn resolve_yes(&self) {
+        self.env.advance_time(Duration::seconds(CLOSE_DELAY));
+        self.env.mock_all_auths();
+        self.client().resolve(&self.admin, &Outcome::Yes);
+    }
+}
+
+#[test]
+fn test_initialize_sets_open_market_state() {
+    let ctx = Ctx::setup();
+    ctx.initialize();
+
+    let state = ctx.client().get_state();
+    assert_eq!(state.admin, ctx.admin.address());
+    assert_eq!(state.token, ctx.token.address());
+    assert_eq!(state.close_time, BASE_TIME + CLOSE_DELAY);
+    assert_eq!(state.status, MarketStatus::Open);
+    assert_eq!(state.yes_total, 0);
+    assert_eq!(state.no_total, 0);
+}
+
+#[test]
+fn test_initialize_rejects_past_close_time() {
+    let ctx = Ctx::setup();
+    ctx.env.mock_all_auths();
+    assert_reverts!(
+        ctx.client()
+            .initialize(&ctx.admin, &ctx.token.address(), &BASE_TIME),
+        "close time"
+    );
+}
+
+#[test]
+fn test_double_initialize_reverts() {
+    let ctx = Ctx::setup();
+    ctx.initialize();
+    assert_reverts!(
+        ctx.client()
+            .initialize(&ctx.admin, &ctx.token.address(), &(BASE_TIME + CLOSE_DELAY)),
+        "already initialized"
+    );
+}
+
+#[test]
+fn test_buy_transfers_collateral_and_tracks_position() {
+    let ctx = Ctx::setup();
+    ctx.initialize();
+    ctx.env.mock_all_auths();
+    ctx.client().buy(&ctx.alice, &Outcome::Yes, &ALICE_STAKE);
+
+    assert_eq!(
+        ctx.client().position(&ctx.alice, &Outcome::Yes),
+        ALICE_STAKE
+    );
+    assert_eq!(ctx.client().pool_total(), ALICE_STAKE);
+    assert_eq!(ctx.token.balance(&ctx.id), ALICE_STAKE);
+    assert_eq!(ctx.token.balance(&ctx.alice), 2_000_000 - ALICE_STAKE);
+}
+
+#[test]
+fn test_buy_accumulates_multiple_positions() {
+    let ctx = Ctx::setup();
+    ctx.initialize();
+    ctx.env.mock_all_auths();
+    ctx.client().buy(&ctx.alice, &Outcome::Yes, &ALICE_STAKE);
+    ctx.client().buy(&ctx.alice, &Outcome::Yes, &BOB_STAKE);
+    ctx.client().buy(&ctx.carol, &Outcome::No, &CAROL_STAKE);
+
+    let state = ctx.client().get_state();
+    assert_eq!(ctx.client().position(&ctx.alice, &Outcome::Yes), 1_000_000);
+    assert_eq!(state.yes_total, 1_000_000);
+    assert_eq!(state.no_total, CAROL_STAKE);
+}
+
+#[test]
+fn test_buy_rejects_zero_amount() {
+    let ctx = Ctx::setup();
+    ctx.initialize();
+    ctx.env.mock_all_auths();
+    assert_reverts!(
+        ctx.client().buy(&ctx.alice, &Outcome::Yes, &0_i128),
+        "positive"
+    );
+}
+
+#[test]
+fn test_buy_after_close_reverts() {
+    let ctx = Ctx::setup();
+    ctx.initialize();
+    ctx.env.advance_time(Duration::seconds(CLOSE_DELAY));
+    ctx.env.mock_all_auths();
+    assert_reverts!(
+        ctx.client().buy(&ctx.alice, &Outcome::Yes, &ALICE_STAKE),
+        "closed"
+    );
+}
+
+#[test]
+fn test_only_admin_can_resolve() {
+    let ctx = Ctx::setup();
+    ctx.fund_market();
+    ctx.env.advance_time(Duration::seconds(CLOSE_DELAY));
+    ctx.env.mock_all_auths();
+    assert_reverts!(
+        ctx.client().resolve(&ctx.alice, &Outcome::Yes),
+        "only the admin"
+    );
+}
+
+#[test]
+fn test_resolve_before_close_reverts() {
+    let ctx = Ctx::setup();
+    ctx.fund_market();
+    ctx.env.mock_all_auths();
+    assert_reverts!(
+        ctx.client().resolve(&ctx.admin, &Outcome::Yes),
+        "still open"
+    );
+}
+
+#[test]
+fn test_resolve_sets_winning_outcome() {
+    let ctx = Ctx::setup();
+    ctx.fund_market();
+    ctx.resolve_yes();
+
+    let state = ctx.client().get_state();
+    assert_eq!(state.status, MarketStatus::Resolved);
+    assert_eq!(state.winning_outcome, Outcome::Yes);
+}
+
+#[test]
+fn test_double_resolve_reverts() {
+    let ctx = Ctx::setup();
+    ctx.fund_market();
+    ctx.resolve_yes();
+    assert_reverts!(
+        ctx.client().resolve(&ctx.admin, &Outcome::No),
+        "already resolved"
+    );
+}
+
+#[test]
+fn test_claim_before_resolution_reverts() {
+    let ctx = Ctx::setup();
+    ctx.fund_market();
+    ctx.env.mock_all_auths();
+    assert_reverts!(ctx.client().claim(&ctx.alice), "not resolved");
+}
+
+#[test]
+fn test_winners_claim_proportional_payouts() {
+    let ctx = Ctx::setup();
+    ctx.fund_market();
+    ctx.resolve_yes();
+
+    let pool = ALICE_STAKE + BOB_STAKE + CAROL_STAKE;
+    let alice_expected = ALICE_STAKE * pool / (ALICE_STAKE + BOB_STAKE);
+    let bob_expected = BOB_STAKE * pool / (ALICE_STAKE + BOB_STAKE);
+
+    ctx.env.mock_all_auths();
+    assert_eq!(ctx.client().claim(&ctx.alice), alice_expected);
+    assert_eq!(ctx.client().claim(&ctx.bob), bob_expected);
+
+    assert_eq!(
+        ctx.token.balance(&ctx.alice),
+        2_000_000 - ALICE_STAKE + alice_expected
+    );
+    assert_eq!(
+        ctx.token.balance(&ctx.bob),
+        2_000_000 - BOB_STAKE + bob_expected
+    );
+    assert_eq!(ctx.client().position(&ctx.alice, &Outcome::Yes), 0);
+    assert_eq!(ctx.client().position(&ctx.bob, &Outcome::Yes), 0);
+}
+
+#[test]
+fn test_losing_position_cannot_claim() {
+    let ctx = Ctx::setup();
+    ctx.fund_market();
+    ctx.resolve_yes();
+    ctx.env.mock_all_auths();
+    assert_reverts!(ctx.client().claim(&ctx.carol), "no winning position");
+}
+
+#[test]
+fn test_double_claim_reverts() {
+    let ctx = Ctx::setup();
+    ctx.fund_market();
+    ctx.resolve_yes();
+    ctx.env.mock_all_auths();
+    ctx.client().claim(&ctx.alice);
+    assert_reverts!(ctx.client().claim(&ctx.alice), "no winning position");
+}
+
+#[test]
+fn test_no_side_can_win_and_claim_full_pool() {
+    let ctx = Ctx::setup();
+    ctx.fund_market();
+    ctx.env.advance_time(Duration::seconds(CLOSE_DELAY));
+    ctx.env.mock_all_auths();
+    ctx.client().resolve(&ctx.admin, &Outcome::No);
+
+    let pool = ALICE_STAKE + BOB_STAKE + CAROL_STAKE;
+    assert_eq!(ctx.client().claim(&ctx.carol), pool);
+    assert_eq!(
+        ctx.token.balance(&ctx.carol),
+        2_000_000 - CAROL_STAKE + pool
+    );
+}
+
+#[test]
+fn test_initialize_emits_event() {
+    let ctx = Ctx::setup();
+    ctx.initialize();
+    assert_emitted!(
+        ctx.env,
+        ctx.id,
+        (symbol_short!("init"),),
+        BASE_TIME + CLOSE_DELAY
+    );
+}


### PR DESCRIPTION
closes #394 
Summary
Adds a new Soroban prediction market contract example with:

Binary YES/NO outcomes
Token-collateralized market positions
Admin-controlled resolution after market close
Proportional payouts for winning positions
Protection against invalid buys, early resolution, double resolution, losing claims, and double claims
Unit tests covering lifecycle, accounting, timing, auth, and payout behavior

Reason
This implements the MVP-critical Prediction Market contract requested in issue #394, integrating it cleanly into the existing examples workspace and following the established contract/test structure.