### PR TITLE
Validate treasury init inputs and add contract errors

### DIFF
--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -22,6 +22,14 @@ pub enum ContractError {
     NotAdmin = 1,
     InsufficientQuorum = 2,
     InsufficientBalance = 3,
+    /// `initialize` was called after the contract was already set up.
+    AlreadyInitialized = 4,
+    /// The admins vector passed to `initialize` was empty.
+    EmptyAdmins = 5,
+    /// `quorum` was zero or exceeded the number of admins.
+    InvalidQuorum = 6,
+    /// The admins vector contained duplicate addresses.
+    DuplicateAdmin = 7,
 }
 
 #[contract]
@@ -30,14 +38,33 @@ pub struct Treasury;
 #[contractimpl]
 impl Treasury {
     /// Initialize the treasury with a list of admin addresses and a quorum threshold.
+    ///
+    /// # Errors
+    /// - [`ContractError::AlreadyInitialized`] — called more than once.
+    /// - [`ContractError::EmptyAdmins`] — `admins` is empty.
+    /// - [`ContractError::InvalidQuorum`] — `quorum` is 0 or greater than `admins.len()`.
+    /// - [`ContractError::DuplicateAdmin`] — `admins` contains duplicate addresses.
     pub fn initialize(env: Env, admins: Vec<Address>, quorum: u32) {
-        // Store admins and quorum only once
         if env.storage().instance().has(&DataKey::Admins) {
-            panic!("already initialized");
+            panic_with_error!(&env, ContractError::AlreadyInitialized);
+        }
+        if admins.is_empty() {
+            panic_with_error!(&env, ContractError::EmptyAdmins);
+        }
+        let n = admins.len();
+        if quorum == 0 || quorum > n {
+            panic_with_error!(&env, ContractError::InvalidQuorum);
+        }
+        // O(n²) duplicate check — admin lists are expected to be small
+        for i in 0..n {
+            for j in (i + 1)..n {
+                if admins.get(i).unwrap() == admins.get(j).unwrap() {
+                    panic_with_error!(&env, ContractError::DuplicateAdmin);
+                }
+            }
         }
         env.storage().instance().set(&DataKey::Admins, &admins);
         env.storage().instance().set(&DataKey::Quorum, &quorum);
-        // Initialize empty balances map
         let balances: Map<(Address, Address), i128> = Map::new(&env);
         env.storage().instance().set(&DataKey::Balances, &balances);
         env.events()

--- a/contracts/treasury/tests/treasury_test.rs
+++ b/contracts/treasury/tests/treasury_test.rs
@@ -63,4 +63,51 @@ mod tests {
         let bal = Treasury::balance_of(env.inner(), admin1.address(), Address::from([0; 32]));
         assert_eq!(bal, 600);
     }
+
+    // --- invalid initialization tests ---
+
+    #[test]
+    #[should_panic]
+    fn test_initialize_empty_admins_rejected() {
+        let env = setup_env();
+        Treasury::initialize(env.inner(), Vec::new(&env.inner()), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_initialize_zero_quorum_rejected() {
+        let env = setup_env();
+        let admin1 = env.account("admin1");
+        let admins = Vec::from_array(&env, &[admin1.address()]);
+        Treasury::initialize(env.inner(), admins, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_initialize_quorum_exceeds_admin_count_rejected() {
+        let env = setup_env();
+        let admin1 = env.account("admin1");
+        let admins = Vec::from_array(&env, &[admin1.address()]);
+        Treasury::initialize(env.inner(), admins, 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_initialize_duplicate_admins_rejected() {
+        let env = setup_env();
+        let admin1 = env.account("admin1");
+        let addr = admin1.address();
+        let admins = Vec::from_array(&env, &[addr.clone(), addr]);
+        Treasury::initialize(env.inner(), admins, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_initialize_twice_rejected() {
+        let env = setup_env();
+        let admin1 = env.account("admin1");
+        let admins = Vec::from_array(&env, &[admin1.address()]);
+        Treasury::initialize(env.inner(), admins.clone(), 1);
+        Treasury::initialize(env.inner(), admins, 1);
+    }
 }


### PR DESCRIPTION
Validate treasury initialization inputs
  
  Add input validation to Treasury::initialize and replace string panics with stable contract
  errors.
  
  Changes
  
  - ContractError gains four new variants:
    - AlreadyInitialized (4) — re-initialization blocked
    - EmptyAdmins (5) — admins vec must not be empty
    - InvalidQuorum (6) — quorum must be ≥ 1 and ≤ admin count
    - DuplicateAdmin (7) — all admin addresses must be unique
  
  - initialize now validates all four conditions via panic_with_error! before writing to storage
  - Replaces the previous untyped panic!("already initialized")
  
  Tests added
  
  - test_initialize_empty_admins_rejected
  - test_initialize_zero_quorum_rejected
  - test_initialize_quorum_exceeds_admin_count_rejected
  - test_initialize_duplicate_admins_rejected
  - test_initialize_twice_rejected
 
closes #498 