### PR TITLE
fix: assert_emitted! searches for matching event instead of full-log …

### DIFF
--- a/contracts/crucible/src/macros.rs
+++ b/contracts/crucible/src/macros.rs
@@ -46,9 +46,10 @@ macro_rules! assert_reverts {
 
 /// Asserts that a specific event was emitted (among any others).
 ///
-/// Checks that the event log contains an entry with the given contract address,
-/// topics tuple, and data value. Other events may also be present. Topics are
-/// passed as a tuple and converted to `Vec<Val>` via [`soroban_sdk::IntoVal`].
+/// Searches the event log for at least one entry matching the given contract
+/// address, topics tuple, and data value. Other events may also be present.
+/// Topics are passed as a tuple and converted to `Vec<Val>` via
+/// [`soroban_sdk::IntoVal`].
 ///
 /// # Example
 ///
@@ -66,20 +67,32 @@ macro_rules! assert_emitted {
     ($env:expr, $contract_id:expr, $topics:expr, $data:expr) => {{
         use soroban_sdk::testutils::Events as _;
         use soroban_sdk::IntoVal as _;
+        use soroban_sdk::xdr;
         let __env = $env.inner();
-        let __events = __env.events().all();
-        let __expected_vec = soroban_sdk::vec![
-            __env,
-            (
-                $contract_id.clone(),
-                ($topics).into_val(__env),
-                ($data).into_val(__env),
-            )
-        ];
-        assert_eq!(
-            __events, __expected_vec,
-            "Expected event log to match exactly. Events: {:?}",
-            __events
+        let __all = __env.events().all();
+        let __want_topics: soroban_sdk::Vec<soroban_sdk::Val> = ($topics).into_val(__env);
+        let __want_data: soroban_sdk::Val = ($data).into_val(__env);
+        let __want_contract: soroban_sdk::Address = $contract_id.clone();
+        let __found = __all.events().iter().any(|ev| {
+            let xdr::ContractEventBody::V0(body) = &ev.body;
+            let Some(ref cid) = ev.contract_id else { return false };
+            let sc_addr = xdr::ScAddress::Contract(cid.clone());
+            let ev_contract = soroban_sdk::Address::from_val(__env, &sc_addr);
+            if ev_contract != __want_contract {
+                return false;
+            }
+            let ev_topics: soroban_sdk::Vec<soroban_sdk::Val> =
+                body.topics.clone().into_val(__env);
+            let ev_data: soroban_sdk::Val = body.data.clone().into_val(__env);
+            ev_topics == __want_topics && ev_data == __want_data
+        });
+        assert!(
+            __found,
+            "Expected event not found.\n  contract: {:?}\n  topics:   {:?}\n  data:     {:?}\n  actual events: {:?}",
+            __want_contract,
+            __want_topics,
+            __want_data,
+            __all,
         );
     }};
 }
@@ -104,4 +117,39 @@ macro_rules! assert_not_emitted {
             __events
         );
     }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::env::MockEnv;
+    use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+    // A minimal contract that publishes two events in one call.
+    #[contract]
+    struct MultiEventContract;
+
+    #[contractimpl]
+    impl MultiEventContract {
+        pub fn fire_two(env: Env) {
+            env.events()
+                .publish((symbol_short!("first"),), 1_u32);
+            env.events()
+                .publish((symbol_short!("second"),), 2_u32);
+        }
+    }
+
+    #[test]
+    fn test_assert_emitted_finds_event_among_others() {
+        let env = MockEnv::builder()
+            .with_contract::<MultiEventContract>()
+            .build();
+        let id = env.contract_id::<MultiEventContract>();
+        let client = MultiEventContractClient::new(env.inner(), &id);
+
+        client.fire_two();
+
+        // Each event should be found even though two events are present.
+        crate::assert_emitted!(env, id, (symbol_short!("first"),), 1_u32);
+        crate::assert_emitted!(env, id, (symbol_short!("second"),), 2_u32);
+    }
 }


### PR DESCRIPTION
 fix: assert_emitted! searches for matching event instead of full-log equality
  
  assert_emitted! previously built a single-element vec and compared it with assert_eq! against
  the entire event log. This failed whenever a contract emitted more than one event — including
  the diagnostic fn_call/fn_return events Soroban always injects.
  
  The macro now iterates the XDR event log and asserts that at least one entry matches the
  expected contract, topics, and data. Other events may be present without causing a failure.
  
  On failure the error message includes the expected contract, topics, data, and the full actual
  event log.
  
  A new test (test_assert_emitted_finds_event_among_others) covers the case: a contract that
  emits two events in one call, with both asserted successfully.

▸ Closes #462 