### PR TITLE
Add mockenvbuilder with contract at

### DIFF
--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -258,9 +258,11 @@ impl MockEnv {
             }
             let mut matches = true;
             for (i, filter_topic) in filter_topics.iter().enumerate() {
-                if format!("{:?}", filter_topic)
-                    != format!("{:?}", event_topics.get(i as u32).unwrap())
-                {
+                // Compare Soroban `Val` values directly instead of relying on
+                // Debug string formatting. This provides robust type-aware
+                // equality checking (symbols, addresses, integers, tuples, etc.).
+                let ev_topic = event_topics.get(i as u32).unwrap();
+                if filter_topic != ev_topic {
                     matches = false;
                     break;
                 }

--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -452,6 +452,22 @@ impl MockEnvBuilder {
         self
     }
 
+    /// Register a contract at a deterministic address.
+    ///
+    /// This allows tests to associate a contract type with a known `Address` so
+    /// that callers can look up the address deterministically via
+    /// `env.contract_id::<C>()`. Note: this registers the mapping in the
+    /// `MockEnv` but does not deploy the contract instance to the underlying
+    /// `soroban_sdk::Env`. Use `with_contract` if you need the instance to be
+    /// available for calls.
+    pub fn with_contract_at<C>(self, id: &Address) -> Self
+    where
+        C: soroban_sdk::testutils::ContractFunctionSet + Default + 'static,
+    {
+        self.env.register_contract::<C>(id.clone());
+        self
+    }
+
     /// Add a named account with XLM balance.
     pub fn with_account(mut self, name: &str, balance: Stroops) -> Self {
         self.account_configs.push((name.to_string(), balance));


### PR DESCRIPTION
# Pull Request: Add `MockEnvBuilder::with_contract_at` & Improve Event Topic Matching

## Summary
This PR introduces helper utilities for deterministic contract registration in `MockEnvBuilder` and refactors event topic matching within `MockEnv` to compare `Val` values directly rather than formatting them to debug strings.

## Key Changes

### 1. Deterministic Contract Registration
- Added `MockEnvBuilder::with_contract_at::<C>(self, id: &Address) -> Self` inside `contracts/crucible/src/env.rs`.
- This enables registering a specific contract type `C` at a predetermined mock `Address` within the test environment, facilitating tests that rely on deterministic contract address lookups (via `env.contract_id::<C>()`).

### 2. Type-Aware Event Topic Comparison
- Refactored the event verification loop in `MockEnv::assert_emitted_event` to compare Soroban `Val` topics directly (`filter_topic != ev_topic`) instead of using debug-formatted string comparison (`format!("{:?}", ...)`).
- This avoids formatting overhead and provides a more robust, type-aware equality assertion for symbols, addresses, integers, and nested tuples.

## Files Changed
- `contracts/crucible/src/env.rs`

## Verification
- Verified compilation and confirmed that tests run correctly.


Closes #472 
Closes #466 
Closes #458 
Closes #471 