### PR TITLE
fix: address issues 484, 488, 502, 504

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint doc build build-contracts build-backend run-backend
+.PHONY: test lint doc build build-contracts build-backend run-backend db-migrate
 
 test:
 	cargo test --workspace --all-features
@@ -18,6 +18,9 @@ build-backend:
 
 run-backend:
 	cargo run --package backend
+
+db-migrate:
+	sqlx migrate run --source backend/migrations
 
 doc:
 	cargo doc --workspace --no-deps --all-features --open

--- a/backend/README.md
+++ b/backend/README.md
@@ -123,12 +123,28 @@ curl http://localhost:8080/metrics
 curl http://localhost:8080/api/v1/status
 ```
 
+### Applying Database Migrations
+SQLx migrations live in `backend/migrations/`. Apply them after the database is running:
+```bash
+export DATABASE_URL=postgres://crucible:crucible_secret@localhost:5432/crucible_db
+sqlx migrate run --source backend/migrations
+# or from the repo root:
+make db-migrate
+```
+
+Verify migration state at any time with:
+```bash
+sqlx migrate info --source backend/migrations
+```
+
 ### Local Development (without Docker)
 Run Postgres and Redis in Docker, but the Rust app natively:
 ```bash
 docker compose up -d postgres redis
 export DATABASE_URL=postgres://crucible:crucible_secret@localhost:5432/crucible_db
 export REDIS_URL=redis://:crucible_redis_secret@localhost:6379/0
+# Apply migrations before starting the app
+sqlx migrate run --source backend/migrations
 cargo run
 ```
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -6,11 +6,9 @@ pub mod db;
 pub mod error;
 pub mod jobs;
 pub mod services;
-pub mod workers;
-pub mod config;
 pub mod telemetry;
-pub mod workers;
 pub mod utils;
+pub mod workers;
 
 #[cfg(any(test, feature = "testutils"))]
 pub mod test_utils;

--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -385,6 +385,10 @@ impl MockEnv {
     }
 
     /// Simulate a contract call and return a dry-run result.
+    ///
+    /// Auth is globally bypassed only for the duration of the dry-run call.
+    /// After `simulate` returns the auth mock is cleared, so subsequent
+    /// operations require explicit auth setup and will not silently pass.
     pub fn simulate<F, T>(&self, f: F) -> SimulatedTx<T>
     where
         F: Fn() -> T + 'static,
@@ -393,13 +397,12 @@ impl MockEnv {
         let mut budget = self.inner.budget();
         budget.reset_default();
 
-        self.inner.mock_auths(&[]);
         self.inner.mock_all_auths();
-
         let result = f();
-
         let instructions = budget.cpu_instruction_cost();
         let auths = self.inner.auths().iter().map(|(a, _)| a.clone()).collect();
+        // Clear the global auth bypass so it does not leak into later operations.
+        self.inner.mock_auths(&[]);
 
         SimulatedTx::new(
             (instructions / 100) as i64,

--- a/crucible-macros/src/lib.rs
+++ b/crucible-macros/src/lib.rs
@@ -120,6 +120,11 @@ pub fn fixture(args: TokenStream, input: TokenStream) -> TokenStream {
             ///
             /// This is a convenience shorthand for `*self = Self::setup()`.  Use it to
             /// restore a clean environment between logical sections of a single test.
+            ///
+            /// # Compile error
+            ///
+            /// If you see a compiler error pointing here, add a `pub fn setup() -> Self`
+            /// associated function to the struct's `impl` block.
             pub fn reset(&mut self) {
                 *self = Self::setup();
             }


### PR DESCRIPTION
## Summary

- Removes duplicate `config` and `workers` module declarations in `backend/src/lib.rs` and sorts modules alphabetically.
- Documents the SQLx migration setup step in `backend/README.md` and adds a `make db-migrate` target to the root `Makefile`.
- Improves the `#[fixture]` macro's `reset()` doc comment to explicitly guide users toward adding `pub fn setup() -> Self` when they hit a compile error.
- Fixes `MockEnv::simulate` to clear the global auth bypass (`mock_all_auths`) immediately after the dry-run call, preventing it from leaking into subsequent test operations.

## Test plan

- [ ] `cargo check -p backend` passes with no duplicate-module errors
- [ ] `cargo doc -p crucible-macros` renders the updated `reset()` doc note
- [ ] Existing `crucible-macros` trybuild test `fail-missing-setup` still matches its `.stderr` snapshot
- [ ] Tests that call `MockEnv::simulate` followed by auth-guarded calls now fail loudly if auth is not explicitly re-configured

Closes #502
Closes #504
Closes #488
Closes #484
