### PR TITLE
Add trybuild coverage for fixture macro failure modes

### DIFF
--- a/crucible-macros/tests/fixture_tests.rs
+++ b/crucible-macros/tests/fixture_tests.rs
@@ -17,9 +17,14 @@ fn fixture_ui_tests() {
     t.pass("tests/ui/pass-basic.rs");
     t.pass("tests/ui/pass-debug-already-derived.rs");
     t.pass("tests/ui/pass-generic.rs");
+    t.pass("tests/ui/pass-private-setup.rs");
 
     // --- fail cases ---
     t.compile_fail("tests/ui/fail-on-enum.rs");
+    t.compile_fail("tests/ui/fail-on-union.rs");
+    t.compile_fail("tests/ui/fail-on-fn.rs");
     t.compile_fail("tests/ui/fail-fixture-args.rs");
+    t.compile_fail("tests/ui/fail-fixture-args-multiple.rs");
     t.compile_fail("tests/ui/fail-missing-setup.rs");
+    t.compile_fail("tests/ui/fail-invalid-generics.rs");
 }

--- a/crucible-macros/tests/ui/fail-fixture-args-multiple.rs
+++ b/crucible-macros/tests/ui/fail-fixture-args-multiple.rs
@@ -1,0 +1,15 @@
+// Multiple unexpected arguments to #[fixture] must produce a clear compile error.
+use crucible_macros::fixture;
+
+#[fixture(foo, bar)]
+pub struct MyFixture {
+    pub value: i32,
+}
+
+impl MyFixture {
+    pub fn setup() -> Self {
+        Self { value: 0 }
+    }
+}
+
+fn main() {}

--- a/crucible-macros/tests/ui/fail-fixture-args-multiple.stderr
+++ b/crucible-macros/tests/ui/fail-fixture-args-multiple.stderr
@@ -1,0 +1,11 @@
+error: #[fixture] does not take arguments
+ --> tests/ui/fail-fixture-args-multiple.rs:4:11
+  |
+4 | #[fixture(foo, bar)]
+  |           ^^^^^^^^
+
+error[E0425]: cannot find type `MyFixture` in this scope
+ --> tests/ui/fail-fixture-args-multiple.rs:9:6
+  |
+9 | impl MyFixture {
+  |      ^^^^^^^^^ not found in this scope

--- a/crucible-macros/tests/ui/fail-invalid-generics.rs
+++ b/crucible-macros/tests/ui/fail-invalid-generics.rs
@@ -1,0 +1,18 @@
+// A generic fixture whose setup() returns the wrong Self type must not compile.
+use crucible_macros::fixture;
+
+#[fixture]
+pub struct GenericFixture<T> {
+    pub value: T,
+}
+
+impl<T> GenericFixture<T> {
+    pub fn setup() -> GenericFixture<u32> {
+        GenericFixture { value: 0 }
+    }
+}
+
+fn main() {
+    let mut f = GenericFixture { value: 0u32 };
+    f.reset();
+}

--- a/crucible-macros/tests/ui/fail-invalid-generics.stderr
+++ b/crucible-macros/tests/ui/fail-invalid-generics.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+ --> tests/ui/fail-invalid-generics.rs:4:1
+  |
+4 | #[fixture]
+  | ^^^^^^^^^^
+  | |
+  | expected `GenericFixture<T>`, found `GenericFixture<u32>`
+  | expected due to the type of this binding
+5 | pub struct GenericFixture<T> {
+  |                           - expected this type parameter
+  |
+  = note: expected struct `GenericFixture<T>`
+             found struct `GenericFixture<u32>`
+  = note: this error originates in the attribute macro `fixture` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crucible-macros/tests/ui/fail-on-fn.rs
+++ b/crucible-macros/tests/ui/fail-on-fn.rs
@@ -1,0 +1,7 @@
+// Applying #[fixture] to a function must not compile.
+use crucible_macros::fixture;
+
+#[fixture]
+fn not_a_fixture() {}
+
+fn main() {}

--- a/crucible-macros/tests/ui/fail-on-fn.stderr
+++ b/crucible-macros/tests/ui/fail-on-fn.stderr
@@ -1,0 +1,5 @@
+error: expected one of: `struct`, `enum`, `union`
+ --> tests/ui/fail-on-fn.rs:5:1
+  |
+5 | fn not_a_fixture() {}
+  | ^^

--- a/crucible-macros/tests/ui/fail-on-union.rs
+++ b/crucible-macros/tests/ui/fail-on-union.rs
@@ -1,0 +1,10 @@
+// Applying #[fixture] to a union must produce a clear compile error.
+use crucible_macros::fixture;
+
+#[fixture]
+pub union MyFixture {
+    pub a: u32,
+    pub b: f32,
+}
+
+fn main() {}

--- a/crucible-macros/tests/ui/fail-on-union.stderr
+++ b/crucible-macros/tests/ui/fail-on-union.stderr
@@ -1,0 +1,5 @@
+error: #[fixture] can only be applied to structs
+ --> tests/ui/fail-on-union.rs:5:11
+  |
+5 | pub union MyFixture {
+  |           ^^^^^^^^^

--- a/crucible-macros/tests/ui/pass-private-setup.rs
+++ b/crucible-macros/tests/ui/pass-private-setup.rs
@@ -1,0 +1,21 @@
+// A fixture with a private setup() in the same module must still compile and reset.
+use crucible_macros::fixture;
+
+#[fixture]
+pub struct PrivateSetupFixture {
+    pub value: i32,
+}
+
+impl PrivateSetupFixture {
+    fn setup() -> Self {
+        Self { value: 1 }
+    }
+}
+
+fn main() {
+    let mut f = PrivateSetupFixture::setup();
+    assert_eq!(f.value, 1);
+    f.value = 99;
+    f.reset();
+    assert_eq!(f.value, 1);
+}


### PR DESCRIPTION
## Summary
- Expands `crucible-macros` trybuild UI tests for `#[fixture]` with four new compile-fail cases (union, function, multiple args, invalid generics) and one compile-pass case (private `setup()`)
- Adds reviewed stderr snapshots for all new failure modes
- Closes #489

## Test plan
- [x] `cargo test -p crucible-macros` — all 11 trybuild cases pass (4 pass + 7 fail)