### PR TITLE
feat(backend): harden CORS configuration for production

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -193,7 +193,31 @@ backend/
 | `REDIS_PASSWORD`          | `crucible_redis_secret`     | Redis authentication password            |
 | `REDIS_POOL_SIZE`         | `5`                         | Redis connection pool size               |
 | `JWT_SECRET`              | *(dev default)*             | JWT signing secret                       |
-| `CORS_ALLOWED_ORIGINS`    | `localhost:3000,5173`       | Comma-separated allowed origins          |
+| `APP_CORS__ALLOWED_ORIGINS__0` | *(none)*               | Allowed CORS origin (use `__0`, `__1`, etc. for multiple) |
+
+### CORS Behavior per Environment
+
+CORS configuration is driven by `cors.allowed_origins` in the config system. The behavior changes with the environment:
+
+| Environment   | Default `allowed_origins` | Wildcard `*` allowed? | Behavior                                      |
+|---------------|---------------------------|------------------------|-----------------------------------------------|
+| Development   | `["*"]`                   | Yes                    | Permissive CORS — any origin, method, header  |
+| Staging       | `[]`                      | **No** (rejected)      | Must set explicit origins or startup fails    |
+| Production    | `[]`                      | **No** (rejected)      | Must set explicit origins or startup fails    |
+
+**Setting origins via environment variables:**
+
+Use indexed keys with the `APP__` prefix. The `config` crate maps `APP_CORS__ALLOWED_ORIGINS__N` to `cors.allowed_origins[N]`:
+
+```
+APP_CORS__ALLOWED_ORIGINS__0=https://app.example.com
+APP_CORS__ALLOWED_ORIGINS__1=https://admin.example.com
+```
+
+**Startup validation:**
+In Production or Staging, the application refuses to start if `allowed_origins` is empty or contains the wildcard `"*"`. The error message directs you to set explicit origins.
+
+**SEP-1 exception:** The `/.well-known/stellar.toml` endpoint always returns `Access-Control-Allow-Origin: *` — this is required by the Stellar protocol for wallet discovery and is independent of the application CORS configuration.
 
 ## Docker Compose Features
 
@@ -321,7 +345,7 @@ For production, update the following:
 2. **Set `APP_ENV=production`**
 3. **Set `RUST_LOG=crucible_backend=info,tower_http=info`** — reduce log verbosity
 4. **Set a strong `JWT_SECRET`** — at least 64 characters
-5. **Restrict `CORS_ALLOWED_ORIGINS`** — to your frontend domain(s)
+5. **Set explicit `APP_CORS__ALLOWED_ORIGINS__0`** — to your frontend domain(s). Wildcard `*` is rejected in production.
 6. **Consider external managed databases** — for PostgreSQL and Redis at scale
 7. **Add TLS termination** — via a reverse proxy (nginx, Caddy, or cloud LB)
 

--- a/backend/src/config/cors.rs
+++ b/backend/src/config/cors.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+/// CORS configuration controlling which origins may access the API.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CorsConfig {
+    /// Allowed origins. Use `["*"]` for permissive development; production must
+    /// list explicit origins.
+    #[serde(default = "default_allowed_origins")]
+    pub allowed_origins: Vec<String>,
+}
+
+fn default_allowed_origins() -> Vec<String> {
+    vec!["*".to_string()]
+}
+
+impl Default for CorsConfig {
+    fn default() -> Self {
+        Self {
+            allowed_origins: default_allowed_origins(),
+        }
+    }
+}

--- a/backend/src/config/defaults/default.toml
+++ b/backend/src/config/defaults/default.toml
@@ -15,6 +15,9 @@ pool_size = 10
 connection_timeout_ms = 5000
 max_retries = 3
 
+[cors]
+allowed_origins = ["*"]
+
 [observability]
 log_level = "info"
 tracing_endpoint = "http://localhost:4318/v1/traces"

--- a/backend/src/config/defaults/development.toml
+++ b/backend/src/config/defaults/development.toml
@@ -12,6 +12,9 @@ idle_timeout_secs = 3600 # Longer for easier local debugging
 [redis]
 pool_size = 5
 
+[cors]
+allowed_origins = ["*"]
+
 [observability]
 log_level = "debug"
 enable_metrics = false

--- a/backend/src/config/defaults/production.toml
+++ b/backend/src/config/defaults/production.toml
@@ -12,6 +12,9 @@ idle_timeout_secs = 120
 [redis]
 pool_size = 100
 
+[cors]
+allowed_origins = []
+
 [observability]
 log_level = "info"
 enable_metrics = true

--- a/backend/src/config/defaults/staging.toml
+++ b/backend/src/config/defaults/staging.toml
@@ -12,6 +12,9 @@ idle_timeout_secs = 300
 [redis]
 pool_size = 50
 
+[cors]
+allowed_origins = []
+
 [observability]
 log_level = "debug"
 enable_metrics = true

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -12,6 +12,7 @@ use config::{Config, Environment as ConfigEnvironment, File, FileFormat};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+pub mod cors;
 pub mod database;
 pub mod error;
 pub mod observability;
@@ -22,6 +23,7 @@ pub mod server;
 #[cfg(test)]
 mod tests;
 
+pub use cors::CorsConfig;
 pub use database::DatabaseConfig;
 pub use error::ConfigError;
 pub use observability::ObservabilityConfig;
@@ -94,6 +96,8 @@ pub struct AppConfig {
     pub database: DatabaseConfig,
     pub redis: RedisConfig,
     pub observability: ObservabilityConfig,
+    #[serde(default)]
+    pub cors: CorsConfig,
 }
 
 // Temporary fallback for testing/reloading if missing in main.rs
@@ -164,6 +168,22 @@ impl AppConfig {
 
         if self.redis.pool_size == 0 {
             errors.push("Redis pool_size must be greater than 0.".to_string());
+        }
+
+        if env == Environment::Production || env == Environment::Staging {
+            if self.cors.allowed_origins.is_empty() {
+                errors.push(
+                    "CORS allowed_origins must not be empty in Production/Staging. \
+                     Set explicit origins (e.g. APP_CORS__ALLOWED_ORIGINS__0=https://example.com)."
+                        .to_string(),
+                );
+            } else if self.cors.allowed_origins.contains(&"*".to_string()) {
+                errors.push(
+                    "CORS wildcard '*' is not allowed in Production/Staging. \
+                     Replace with explicit origins (e.g. APP_CORS__ALLOWED_ORIGINS__0=https://example.com)."
+                        .to_string(),
+                );
+            }
         }
 
         if !errors.is_empty() {

--- a/backend/src/config/tests.rs
+++ b/backend/src/config/tests.rs
@@ -89,6 +89,10 @@ fn test_production_missing_tls_validation() {
                 Some("postgres://user:pass@localhost/db"),
             ),
             ("APP_REDIS__URL", Some("redis://localhost:6379")),
+            (
+                "APP_CORS__ALLOWED_ORIGINS__0",
+                Some("https://example.com"),
+            ),
         ],
         || {
             let err = AppConfig::load(Environment::Production)
@@ -118,11 +122,12 @@ fn test_validation_collects_all_errors() {
 
             match err {
                 crate::config::ConfigError::ValidationError(errors) => {
-                    // TLS missing, DB URL empty, Redis URL empty
-                    assert!(errors.len() >= 3);
+                    // TLS missing, DB URL empty, Redis URL empty, CORS origins empty
+                    assert!(errors.len() >= 4);
                     assert!(errors.iter().any(|e| e.contains("TLS configuration")));
                     assert!(errors.iter().any(|e| e.contains("Database URL")));
                     assert!(errors.iter().any(|e| e.contains("Redis URL")));
+                    assert!(errors.iter().any(|e| e.contains("CORS")));
                 }
                 _ => panic!("Expected ValidationError, got {:?}", err),
             }
@@ -197,6 +202,7 @@ fn test_sensitive_fields_redacted_in_debug() {
             tracing_endpoint: None,
             enable_metrics: false,
         },
+        cors: crate::config::CorsConfig::default(),
     };
 
     let debug_str = format!("{:?}", config);
@@ -208,4 +214,61 @@ fn test_sensitive_fields_redacted_in_debug() {
 
     assert!(debug_str.contains("[REDACTED]"));
     assert!(debug_str.contains("/path/to/cert")); // Public cert path is OK
+}
+
+#[test]
+fn test_production_rejects_wildcard_cors() {
+    temp_env::with_vars(
+        [
+            (
+                "APP_DATABASE__URL",
+                Some("postgres://user:pass@localhost/db"),
+            ),
+            ("APP_REDIS__URL", Some("redis://localhost:6379")),
+            ("APP_CORS__ALLOWED_ORIGINS__0", Some("*")),
+        ],
+        || {
+            let err = AppConfig::load(Environment::Production)
+                .expect_err("Should fail with wildcard CORS in production");
+
+            match err {
+                crate::config::ConfigError::ValidationError(errors) => {
+                    assert!(
+                        errors.iter().any(|e| e.contains("CORS wildcard")),
+                        "Expected CORS wildcard error, got: {:?}",
+                        errors
+                    );
+                }
+                _ => panic!("Expected ValidationError, got {:?}", err),
+            }
+        },
+    );
+}
+
+#[test]
+fn test_production_rejects_empty_cors_origins() {
+    temp_env::with_vars(
+        [
+            (
+                "APP_DATABASE__URL",
+                Some("postgres://user:pass@localhost/db"),
+            ),
+            ("APP_REDIS__URL", Some("redis://localhost:6379")),
+        ],
+        || {
+            let err = AppConfig::load(Environment::Production)
+                .expect_err("Should fail with empty CORS origins in production");
+
+            match err {
+                crate::config::ConfigError::ValidationError(errors) => {
+                    assert!(
+                        errors.iter().any(|e| e.contains("CORS allowed_origins must not be empty")),
+                        "Expected CORS empty error, got: {:?}",
+                        errors
+                    );
+                }
+                _ => panic!("Expected ValidationError, got {:?}", err),
+            }
+        },
+    );
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -35,7 +35,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::signal;
 use tower_http::{
-    cors::{Any, CorsLayer},
+    cors::{AllowOrigin, Any, CorsLayer},
     trace::TraceLayer,
 };
 use tracing::info_span;
@@ -156,10 +156,7 @@ async fn main() -> Result<(), anyhow::Error> {
         )
         .route("/logs", get(backend::api::handlers::admin::get_admin_logs));
 
-    let cors = CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods(Any)
-        .allow_headers(Any);
+    let cors = build_cors_layer(&config);
 
     let app = Router::new()
         .route("/", get(|| async { "Crucible Backend API" }))
@@ -284,5 +281,28 @@ async fn shutdown_signal() {
     tokio::select! {
         _ = ctrl_c => tracing::info!("Received Ctrl+C, initiating graceful shutdown"),
         _ = terminate => tracing::info!("Received SIGTERM, initiating graceful shutdown"),
+    }
+}
+
+fn build_cors_layer(config: &AppConfig) -> CorsLayer {
+    if config.cors.allowed_origins.contains(&"*".to_string()) {
+        CorsLayer::new()
+            .allow_origin(Any)
+            .allow_methods(Any)
+            .allow_headers(Any)
+    } else {
+        let origins: Vec<axum::http::HeaderValue> = config
+            .cors
+            .allowed_origins
+            .iter()
+            .map(|o| {
+                o.parse()
+                    .unwrap_or_else(|_| panic!("Invalid CORS origin: {}", o))
+            })
+            .collect();
+        CorsLayer::new()
+            .allow_origin(AllowOrigin::list(origins))
+            .allow_methods(Any)
+            .allow_headers(Any)
     }
 }


### PR DESCRIPTION
Closes #564 

Replaced permissive CorsLayer (Any origin/method/header) with config-driven CORS. 

Development remains permissive; staging and production require explicit origins via APP_CORS__ALLOWED_ORIGINS__0, APP_CORS__ALLOWED_ORIGINS__1, etc. Wildcard '*' is rejected at startup in non-dev environments.

@GideonBature 