### PR TITLE
feat: relax SimulatedTx closure lifetime requirements (#547)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,26 @@ if sim.would_succeed() {
 
 This is particularly valuable in CI when you want to catch unexpectedly expensive code paths or missing authorization requirements, without writing a separate integration test for each scenario.
 
+#### Inspect-Only Simulations
+
+When you only need to inspect the results without committing, use `simulate_inspect`. This method does not require the closure to be `'static`, allowing you to borrow local clients, accounts, or fixture references:
+
+```rust
+// Borrow a local client - no 'static requirement
+let client = MyContractClient::new(&env, &contract_id);
+let alice = env.account("alice");
+
+let inspected = env.simulate_inspect(|| {
+    client.transfer(&alice.address(), &amount)
+});
+
+// Inspect the results
+println!("Fee: {} stroops", inspected.fee());
+println!("Would succeed: {}", inspected.would_succeed());
+```
+
+This is particularly useful in test fixtures where you want to simulate calls using borrowed references without cloning or `'static` workarounds.
+
 ---
 
 ### Event Assertions

--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -5,7 +5,7 @@
 
 use crate::account::AccountHandle;
 use crate::cost::CostReport;
-use crate::sim::SimulatedTx;
+use crate::sim::{InspectedTx, SimulatedTx};
 use soroban_sdk::{
     testutils::{ContractEvents, Events, Ledger},
     Address, Env, FromVal, IntoVal, Val, Vec as SorobanVec,
@@ -425,6 +425,38 @@ impl MockEnv {
             true,
             Some(result),
             Some(Box::new(f)),
+        )
+    }
+
+    /// Inspect a contract call without the ability to commit.
+    ///
+    /// Unlike `simulate`, this method does not require the closure to be `'static`,
+    /// allowing it to borrow local clients, accounts, or fixture references.
+    ///
+    /// Auth is globally bypassed only for the duration of the dry-run call.
+    /// After `simulate_inspect` returns the auth mock is cleared, so subsequent
+    /// operations require explicit auth setup and will not silently pass.
+    pub fn simulate_inspect<F, T>(&self, f: F) -> InspectedTx<T>
+    where
+        F: FnOnce() -> T,
+    {
+        let mut budget = self.inner.budget();
+        budget.reset_default();
+
+        self.inner.mock_all_auths();
+        let result = f();
+        let instructions = budget.cpu_instruction_cost();
+        let fee = self.inner.cost_estimate().fee().total;
+        let auths = self.inner.auths().iter().map(|(a, _)| a.clone()).collect();
+        // Clear the global auth bypass so it does not leak into later operations.
+        self.inner.mock_auths(&[]);
+
+        InspectedTx::new(
+            fee,
+            instructions,
+            auths,
+            true,
+            Some(result),
         )
     }
 }

--- a/contracts/crucible/src/prelude.rs
+++ b/contracts/crucible/src/prelude.rs
@@ -10,6 +10,7 @@ pub use crate::env::Duration;
 pub use crate::env::MockEnv;
 pub use crate::env::MockEnvBuilder;
 pub use crate::env::Stroops;
+pub use crate::sim::InspectedTx;
 pub use crate::sim::SimulatedTx;
 pub use crate::token::MockToken;
 

--- a/contracts/crucible/src/sim.rs
+++ b/contracts/crucible/src/sim.rs
@@ -2,8 +2,68 @@
 
 use soroban_sdk::Address;
 
+/// An inspected transaction that allows viewing the results of a contract call
+/// without the ability to commit state changes.
+///
+/// This type is returned by `MockEnv::simulate_inspect` and does not require
+/// the closure to be `'static`, allowing it to borrow local clients and fixtures.
+pub struct InspectedTx<T> {
+    fee: i64,
+    instructions: u64,
+    required_auths: Vec<Address>,
+    success: bool,
+    result: Option<T>,
+}
+
+impl<T> InspectedTx<T> {
+    /// Internal constructor for `MockEnv`.
+    pub(crate) fn new(
+        fee: i64,
+        instructions: u64,
+        required_auths: Vec<Address>,
+        success: bool,
+        result: Option<T>,
+    ) -> Self {
+        Self {
+            fee,
+            instructions,
+            required_auths,
+            success,
+            result,
+        }
+    }
+
+    /// Returns the estimated network fee in stroops.
+    pub fn fee(&self) -> i64 {
+        self.fee
+    }
+
+    /// Returns the total instruction count consumed by the call.
+    pub fn instructions(&self) -> u64 {
+        self.instructions
+    }
+
+    /// Returns the list of addresses that required authorization during the call.
+    pub fn required_auths(&self) -> Vec<Address> {
+        self.required_auths.clone()
+    }
+
+    /// Returns whether the transaction would succeed if committed.
+    pub fn would_succeed(&self) -> bool {
+        self.success
+    }
+
+    /// Returns the result of the call if it succeeded, or `None` if it failed.
+    pub fn result(&self) -> Option<&T> {
+        self.result.as_ref()
+    }
+}
+
 /// A simulated transaction that allows inspecting the results of a contract call
 /// without committing the state changes.
+///
+/// This type is returned by `MockEnv::simulate` and stores the closure to enable
+/// the `commit()` method, which requires the closure to be `'static`.
 pub struct SimulatedTx<T> {
     fee: i64,
     instructions: u64,
@@ -73,5 +133,67 @@ impl<T> SimulatedTx<T> {
             .take()
             .expect("Transaction already committed or closure was consumed.");
         re_run()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::{MockEnv, MockEnvBuilder, Stroops};
+    use soroban_sdk::Address;
+
+    #[test]
+    fn test_inspected_tx_borrows_local_client() {
+        let env = MockEnv::builder()
+            .with_account("alice", Stroops::xlm(10_000))
+            .build();
+
+        let alice = env.account("alice");
+        let address = alice.address();
+
+        // This works because simulate_inspect doesn't require 'static
+        let inspected = env.simulate_inspect(|| {
+            // We can borrow the address here
+            address.clone()
+        });
+
+        assert!(inspected.would_succeed());
+        assert_eq!(inspected.result(), Some(&address));
+    }
+
+    #[test]
+    fn test_simulated_tx_requires_static() {
+        let env = MockEnv::builder()
+            .with_account("alice", Stroops::xlm(10_000))
+            .build();
+
+        let alice = env.account("alice");
+        let address = alice.address();
+
+        // This requires 'static, so we need to clone or use Arc
+        let address_clone = address.clone();
+        let sim = env.simulate(move || {
+            // Must use owned data, not borrowed
+            address_clone
+        });
+
+        assert!(sim.would_succeed());
+        assert_eq!(sim.result(), Some(&address));
+    }
+
+    #[test]
+    fn test_inspected_tx_inspection_methods() {
+        let env = MockEnv::builder()
+            .with_account("alice", Stroops::xlm(10_000))
+            .build();
+
+        let inspected = env.simulate_inspect(|| {
+            env.account("alice").address()
+        });
+
+        assert!(inspected.would_succeed());
+        assert!(inspected.fee() >= 0);
+        assert!(inspected.instructions() > 0);
+        assert!(inspected.result().is_some());
     }
 }


### PR DESCRIPTION
Closes #547

---

Add new InspectedTx type and simulate_inspect method that doesn't require 'sstatic closures, allowing tests to borrow local clients, accounts, and fixture references without cloning or workarounds.

- Add InspectedTx<T> for inspect-only simulations without commit capability
- Add MockEnv::simulate_inspect<F, T>() with F: FnOnce() -> T (no 'static)
- Preserve existing simulate() method with 'static requirement for commit support
- Add InspectedTx to prelude for easy access
- Update README with inspect-only simulation examples
- Add unit tests demonstrating borrowed reference usage

Commit semantics remain clear: only SimulatedTx can commit, InspectedTx is inspect-only.