### PR TITLE
fix(crucible): remove cdylib crate type - crucible is a test utility library, not a Soroban contract

### DIFF
--- a/contracts/crucible/Cargo.toml
+++ b/contracts/crucible/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [features]
 snapshots = ["serde", "serde_json"]


### PR DESCRIPTION
## Summary

The `contracts/crucible/Cargo.toml` emitted both `cdylib` and `rlib`, but the crate uses `std`, `Rc`, `RefCell`, filesystem snapshot support, and Soroban test utilities. This makes it a **host-side test library**, not an on-chain contract artifact.

## Changes

- Removed `cdylib` from the crate-type list, keeping only `rlib`
- The crate remains usable as a Rust dependency for test utilities

## Acceptance criteria

- [x] Crate type matches the actual runtime model
- [x] Build targets do not imply deployability that the crate cannot support

Closes #530