### PR TITLE
fix: remove crate-wide deprecated API suppression and update SDK calls

### DIFF
--- a/backend/src/services/sandbox.rs
+++ b/backend/src/services/sandbox.rs
@@ -347,6 +347,8 @@ impl ContractExecutor for SorobanContractExecutor {
 
         let args = decode_args(&env, &execution.args_xdr)?;
         let wasm = Bytes::from_slice(&env, &execution.wasm);
+        // Using register_contract_wasm is currently the only straightforward way
+        // to dynamically register an arbitrary WASM blob in the sandbox execution environment.
         #[allow(deprecated)]
         let contract_id = env.register_contract_wasm(None, wasm);
         let symbol = Symbol::new(&env, &execution.function);

--- a/contracts/crucible/src/account.rs
+++ b/contracts/crucible/src/account.rs
@@ -106,7 +106,7 @@ impl<'env> AccountBuilder<'env> {
         let address = self
             .env
             .inner()
-            .register_contract(None, soroban_sdk::testutils::MockAuthContract {});
+            .register(soroban_sdk::testutils::MockAuthContract {}, ());
 
         // 2. Fund XLM if requested
         if self.xlm_balance.as_stroops() > 0 {

--- a/contracts/crucible/src/lib.rs
+++ b/contracts/crucible/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 pub use soroban_sdk;
 pub mod account;
 pub mod cost;

--- a/contracts/crucible/src/token.rs
+++ b/contracts/crucible/src/token.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 //! Mock token contract for testing Soroban contracts.
 //!
 //! Provides `MockToken` - a wrapper around the Stellar Asset Contract (SAC)
@@ -103,10 +102,7 @@ impl MockToken {
         // Create an admin for the XLM token
         let _admin = env
             .inner()
-            .register_contract::<soroban_sdk::testutils::MockAuthContract>(
-                None,
-                soroban_sdk::testutils::MockAuthContract {},
-            );
+            .register(soroban_sdk::testutils::MockAuthContract {}, ());
         let sac = env.inner().register_stellar_asset_contract_v2(_admin);
         let address = sac.address();
         env.set_xlm_token_address(address.clone());
@@ -155,10 +151,7 @@ impl MockToken {
         // Create an admin for the token
         let _admin = env
             .inner()
-            .register_contract::<soroban_sdk::testutils::MockAuthContract>(
-                None,
-                soroban_sdk::testutils::MockAuthContract {},
-            );
+            .register(soroban_sdk::testutils::MockAuthContract {}, ());
         let sac = env.inner().register_stellar_asset_contract_v2(_admin);
         let address = sac.address();
 

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Map};
 
 #[contracttype]

--- a/contracts/insurance/src/lib.rs
+++ b/contracts/insurance/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
 
 #[contracttype]

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Vec};
 
 #[contracttype]

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token, Address,
@@ -82,7 +81,7 @@ impl Treasury {
         depositor.require_auth();
 
         // Perform actual token transfer from depositor to this contract (treasury)
-        token::Client::new(&env, &token).transfer(&depositor, &env.current_contract_address(), &amount);
+        token::TokenClient::new(&env, &token).transfer(&depositor, &env.current_contract_address(), &amount);
 
         // Update internal accounting only after successful transfer
         let mut balances: Map<(Address, Address), i128> =

--- a/examples-copy/escrow/src/lib.rs
+++ b/examples-copy/escrow/src/lib.rs
@@ -64,7 +64,7 @@ impl Escrow {
         depositor.require_auth();
 
         // Pull tokens from depositor into this contract.
-        token::Client::new(&env, &token).transfer(
+        token::TokenClient::new(&env, &token).transfer(
             &depositor,
             &env.current_contract_address(),
             &amount,
@@ -116,7 +116,7 @@ impl Escrow {
         state.status = EscrowStatus::Claimed;
         env.storage().instance().set(&DataKey::State, &state);
 
-        token::Client::new(&env, &state.token).transfer(
+        token::TokenClient::new(&env, &state.token).transfer(
             &env.current_contract_address(),
             &state.recipient,
             &state.amount,
@@ -139,7 +139,7 @@ impl Escrow {
         state.status = EscrowStatus::Refunded;
         env.storage().instance().set(&DataKey::State, &state);
 
-        token::Client::new(&env, &state.token).transfer(
+        token::TokenClient::new(&env, &state.token).transfer(
             &env.current_contract_address(),
             &state.depositor,
             &state.amount,

--- a/examples-copy/vesting/src/lib.rs
+++ b/examples-copy/vesting/src/lib.rs
@@ -54,7 +54,7 @@ impl Vesting {
         duration: u64,
     ) {
         admin.require_auth();
-        token::Client::new(&env, &token).transfer(&admin, &env.current_contract_address(), &total);
+        token::TokenClient::new(&env, &token).transfer(&admin, &env.current_contract_address(), &total);
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(
             &DataKey::Schedule,
@@ -103,7 +103,7 @@ impl Vesting {
         }
         s.claimed += claimable;
         env.storage().instance().set(&DataKey::Schedule, &s);
-        token::Client::new(&env, &s.token).transfer(
+        token::TokenClient::new(&env, &s.token).transfer(
             &env.current_contract_address(),
             &s.beneficiary,
             &claimable,
@@ -125,7 +125,7 @@ impl Vesting {
         s.revoked = true;
         env.storage().instance().set(&DataKey::Schedule, &s);
         if unvested > 0 {
-            token::Client::new(&env, &s.token).transfer(
+            token::TokenClient::new(&env, &s.token).transfer(
                 &env.current_contract_address(),
                 &admin,
                 &unvested,

--- a/examples/counter copy/src/lib.rs
+++ b/examples/counter copy/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env};
 
 #[contracttype]

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env};
 
 #[contracttype]

--- a/examples/cross-contract/src/lib.rs
+++ b/examples/cross-contract/src/lib.rs
@@ -8,7 +8,6 @@
 //! - [`Aggregator`] — calls `Router` to orchestrate multi-step workflows,
 //!   showing a two-level call chain.
 #![no_std]
-#![allow(deprecated)]
 
 use soroban_sdk::{
     contract, contractclient, contractimpl, contracttype, symbol_short, token, Address, Env,
@@ -76,7 +75,7 @@ pub trait CounterInterface {
 ///
 /// Demonstrates:
 /// - Calling another contract via a generated client (`CounterClient`).
-/// - Calling a token contract via `token::Client`.
+/// - Calling a token contract via `token::TokenClient`.
 /// - Storing cross-contract addresses in instance storage.
 #[contract]
 #[derive(Default)]
@@ -110,7 +109,7 @@ impl Router {
     pub fn route_transfer(env: Env, from: Address, to: Address, amount: i128) {
         from.require_auth();
         let token_addr: Address = env.storage().instance().get(&RouterKey::Token).unwrap();
-        token::Client::new(&env, &token_addr).transfer(&from, &to, &amount);
+        token::TokenClient::new(&env, &token_addr).transfer(&from, &to, &amount);
         env.events().publish((symbol_short!("routed"),), amount);
     }
 

--- a/examples/emergency_stop/src/lib.rs
+++ b/examples/emergency_stop/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
 
 #[contracttype]

--- a/examples/escrow/src/lib.rs
+++ b/examples/escrow/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
 /// Current state of the escrow.
@@ -65,7 +64,7 @@ impl Escrow {
         depositor.require_auth();
 
         // Pull tokens from depositor into this contract.
-        token::Client::new(&env, &token).transfer(
+        token::TokenClient::new(&env, &token).transfer(
             &depositor,
             env.current_contract_address(),
             &amount,
@@ -117,7 +116,7 @@ impl Escrow {
         state.status = EscrowStatus::Claimed;
         env.storage().instance().set(&DataKey::State, &state);
 
-        token::Client::new(&env, &state.token).transfer(
+        token::TokenClient::new(&env, &state.token).transfer(
             &env.current_contract_address(),
             &state.recipient,
             &state.amount,
@@ -140,7 +139,7 @@ impl Escrow {
         state.status = EscrowStatus::Refunded;
         env.storage().instance().set(&DataKey::State, &state);
 
-        token::Client::new(&env, &state.token).transfer(
+        token::TokenClient::new(&env, &state.token).transfer(
             &env.current_contract_address(),
             &state.depositor,
             &state.amount,

--- a/examples/gasless/src/lib.rs
+++ b/examples/gasless/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
 /// A meta-transaction (gasless) request signed by the user.
@@ -95,7 +94,7 @@ impl Gasless {
             .set(&DataKey::Nonce(meta_tx.from.clone()), &(expected_nonce + 1));
 
         // Execute the transfer.
-        token::Client::new(&env, &meta_tx.token).transfer(
+        token::TokenClient::new(&env, &meta_tx.token).transfer(
             &meta_tx.from,
             &meta_tx.to,
             &meta_tx.amount,

--- a/examples/lending/src/lib.rs
+++ b/examples/lending/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
@@ -121,7 +120,7 @@ impl Lending {
         position.supplied_scaled = Self::checked_add(position.supplied_scaled, scaled);
         state.total_supplied = Self::checked_add(state.total_supplied, amount);
 
-        token::Client::new(&env, &config.asset).transfer(
+        token::TokenClient::new(&env, &config.asset).transfer(
             &lender,
             &env.current_contract_address(),
             &amount,
@@ -153,7 +152,7 @@ impl Lending {
 
         Self::save_position(&env, lender.clone(), &position);
         Self::save_state(&env, &state);
-        token::Client::new(&env, &config.asset).transfer(
+        token::TokenClient::new(&env, &config.asset).transfer(
             &env.current_contract_address(),
             &lender,
             &amount,
@@ -173,7 +172,7 @@ impl Lending {
         position.collateral = Self::checked_add(position.collateral, amount);
         state.total_collateral = Self::checked_add(state.total_collateral, amount);
 
-        token::Client::new(&env, &config.collateral_asset).transfer(
+        token::TokenClient::new(&env, &config.collateral_asset).transfer(
             &borrower,
             &env.current_contract_address(),
             &amount,
@@ -201,7 +200,7 @@ impl Lending {
 
         Self::save_position(&env, borrower.clone(), &position);
         Self::save_state(&env, &state);
-        token::Client::new(&env, &config.collateral_asset).transfer(
+        token::TokenClient::new(&env, &config.collateral_asset).transfer(
             &env.current_contract_address(),
             &borrower,
             &amount,
@@ -230,7 +229,7 @@ impl Lending {
 
         Self::save_position(&env, borrower.clone(), &position);
         Self::save_state(&env, &state);
-        token::Client::new(&env, &config.asset).transfer(
+        token::TokenClient::new(&env, &config.asset).transfer(
             &env.current_contract_address(),
             &borrower,
             &amount,
@@ -259,7 +258,7 @@ impl Lending {
         position.borrowed_scaled = Self::scale_down(remaining, state.borrow_index);
         state.total_borrowed = Self::checked_sub(state.total_borrowed, paid);
 
-        token::Client::new(&env, &config.asset).transfer(
+        token::TokenClient::new(&env, &config.asset).transfer(
             &borrower,
             &env.current_contract_address(),
             &paid,

--- a/examples/lendings/src/lib.rs
+++ b/examples/lendings/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
@@ -121,7 +120,7 @@ impl Lending {
         position.supplied_scaled = Self::checked_add(position.supplied_scaled, scaled);
         state.total_supplied = Self::checked_add(state.total_supplied, amount);
 
-        token::Client::new(&env, &config.asset).transfer(
+        token::TokenClient::new(&env, &config.asset).transfer(
             &lender,
             &env.current_contract_address(),
             &amount,
@@ -153,7 +152,7 @@ impl Lending {
 
         Self::save_position(&env, lender.clone(), &position);
         Self::save_state(&env, &state);
-        token::Client::new(&env, &config.asset).transfer(
+        token::TokenClient::new(&env, &config.asset).transfer(
             &env.current_contract_address(),
             &lender,
             &amount,
@@ -173,7 +172,7 @@ impl Lending {
         position.collateral = Self::checked_add(position.collateral, amount);
         state.total_collateral = Self::checked_add(state.total_collateral, amount);
 
-        token::Client::new(&env, &config.collateral_asset).transfer(
+        token::TokenClient::new(&env, &config.collateral_asset).transfer(
             &borrower,
             &env.current_contract_address(),
             &amount,
@@ -201,7 +200,7 @@ impl Lending {
 
         Self::save_position(&env, borrower.clone(), &position);
         Self::save_state(&env, &state);
-        token::Client::new(&env, &config.collateral_asset).transfer(
+        token::TokenClient::new(&env, &config.collateral_asset).transfer(
             &env.current_contract_address(),
             &borrower,
             &amount,
@@ -230,7 +229,7 @@ impl Lending {
 
         Self::save_position(&env, borrower.clone(), &position);
         Self::save_state(&env, &state);
-        token::Client::new(&env, &config.asset).transfer(
+        token::TokenClient::new(&env, &config.asset).transfer(
             &env.current_contract_address(),
             &borrower,
             &amount,
@@ -259,7 +258,7 @@ impl Lending {
         position.borrowed_scaled = Self::scale_down(remaining, state.borrow_index);
         state.total_borrowed = Self::checked_sub(state.total_borrowed, paid);
 
-        token::Client::new(&env, &config.asset).transfer(
+        token::TokenClient::new(&env, &config.asset).transfer(
             &borrower,
             &env.current_contract_address(),
             &paid,

--- a/examples/multisig/src/lib.rs
+++ b/examples/multisig/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Vec};
 
 #[contracttype]

--- a/examples/pending/src backup/lib.rs
+++ b/examples/pending/src backup/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
 /// A meta-transaction (gasless) request signed by the user.
@@ -95,7 +94,7 @@ impl Gasless {
             .set(&DataKey::Nonce(meta_tx.from.clone()), &(expected_nonce + 1));
 
         // Execute the transfer.
-        token::Client::new(&env, &meta_tx.token).transfer(
+        token::TokenClient::new(&env, &meta_tx.token).transfer(
             &meta_tx.from,
             &meta_tx.to,
             &meta_tx.amount,

--- a/examples/pending/src/lib.rs
+++ b/examples/pending/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
 /// A meta-transaction (gasless) request signed by the user.
@@ -95,7 +94,7 @@ impl Gasless {
             .set(&DataKey::Nonce(meta_tx.from.clone()), &(expected_nonce + 1));
 
         // Execute the transfer.
-        token::Client::new(&env, &meta_tx.token).transfer(
+        token::TokenClient::new(&env, &meta_tx.token).transfer(
             &meta_tx.from,
             &meta_tx.to,
             &meta_tx.amount,

--- a/examples/prediction-market/src/lib.rs
+++ b/examples/prediction-market/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
 /// Binary outcome supported by the prediction market.
@@ -100,7 +99,7 @@ impl PredictionMarket {
         }
         trader.require_auth();
 
-        token::Client::new(&env, &state.token).transfer(
+        token::TokenClient::new(&env, &state.token).transfer(
             &trader,
             env.current_contract_address(),
             &amount,
@@ -163,7 +162,7 @@ impl PredictionMarket {
 
         let payout = Self::payout(&state, position);
         env.storage().instance().set(&key, &0_i128);
-        token::Client::new(&env, &state.token).transfer(
+        token::TokenClient::new(&env, &state.token).transfer(
             &env.current_contract_address(),
             &trader,
             &payout,

--- a/examples/staking/src/lib.rs
+++ b/examples/staking/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
 /// Per-staker record.
@@ -59,7 +58,7 @@ impl Staking {
         staker.require_auth();
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
-        token::Client::new(&env, &token_addr).transfer(
+        token::TokenClient::new(&env, &token_addr).transfer(
             &staker,
             &env.current_contract_address(),
             &amount,
@@ -145,7 +144,7 @@ impl Staking {
             .remove(&DataKey::Stake(staker.clone()));
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
-        token::Client::new(&env, &token_addr).transfer(
+        token::TokenClient::new(&env, &token_addr).transfer(
             &env.current_contract_address(),
             &staker,
             &info.amount,

--- a/examples/time_locked_vault/src/lib.rs
+++ b/examples/time_locked_vault/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
 /// A single deposit held in the vault.
@@ -55,7 +54,7 @@ impl TimeLockedVault {
         }
         owner.require_auth();
 
-        token::Client::new(&env, &token).transfer(&owner, &env.current_contract_address(), &amount);
+        token::TokenClient::new(&env, &token).transfer(&owner, &env.current_contract_address(), &amount);
 
         let id: u64 = env
             .storage()
@@ -103,7 +102,7 @@ impl TimeLockedVault {
         dep.withdrawn = true;
         env.storage().instance().set(&DataKey::Deposit(id), &dep);
 
-        token::Client::new(&env, &dep.token).transfer(
+        token::TokenClient::new(&env, &dep.token).transfer(
             &env.current_contract_address(),
             &dep.owner,
             &dep.amount,

--- a/examples/token/src/lib.rs
+++ b/examples/token/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
 
 #[contracttype]

--- a/examples/vesting copy/src/lib.rs
+++ b/examples/vesting copy/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
 
 /// Persistent state for the vesting schedule.
@@ -55,7 +54,7 @@ impl Vesting {
         duration: u64,
     ) {
         admin.require_auth();
-        token::Client::new(&env, &token).transfer(&admin, env.current_contract_address(), &total);
+        token::TokenClient::new(&env, &token).transfer(&admin, env.current_contract_address(), &total);
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(
             &DataKey::Schedule,
@@ -104,7 +103,7 @@ impl Vesting {
         }
         s.claimed += claimable;
         env.storage().instance().set(&DataKey::Schedule, &s);
-        token::Client::new(&env, &s.token).transfer(
+        token::TokenClient::new(&env, &s.token).transfer(
             &env.current_contract_address(),
             &s.beneficiary,
             &claimable,
@@ -126,7 +125,7 @@ impl Vesting {
         s.revoked = true;
         env.storage().instance().set(&DataKey::Schedule, &s);
         if unvested > 0 {
-            token::Client::new(&env, &s.token).transfer(
+            token::TokenClient::new(&env, &s.token).transfer(
                 &env.current_contract_address(),
                 &admin,
                 &unvested,

--- a/examples/vesting/src/lib.rs
+++ b/examples/vesting/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(deprecated)]
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
 
 /// Persistent state for the vesting schedule.
@@ -55,7 +54,7 @@ impl Vesting {
         duration: u64,
     ) {
         admin.require_auth();
-        token::Client::new(&env, &token).transfer(&admin, env.current_contract_address(), &total);
+        token::TokenClient::new(&env, &token).transfer(&admin, env.current_contract_address(), &total);
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(
             &DataKey::Schedule,
@@ -104,7 +103,7 @@ impl Vesting {
         }
         s.claimed += claimable;
         env.storage().instance().set(&DataKey::Schedule, &s);
-        token::Client::new(&env, &s.token).transfer(
+        token::TokenClient::new(&env, &s.token).transfer(
             &env.current_contract_address(),
             &s.beneficiary,
             &claimable,
@@ -126,7 +125,7 @@ impl Vesting {
         s.revoked = true;
         env.storage().instance().set(&DataKey::Schedule, &s);
         if unvested > 0 {
-            token::Client::new(&env, &s.token).transfer(
+            token::TokenClient::new(&env, &s.token).transfer(
                 &env.current_contract_address(),
                 &admin,
                 &unvested,


### PR DESCRIPTION
# Closes #529 

Summary
  This PR removes the broad  #![allow(deprecated)]  attributes across the
  workspace, replacing deprecated Soroban SDK APIs with their modern
  equivalents, and narrowly scoping and justifying any unavoidable usages.

  What Changed

  • Removed  #![allow(deprecated)]  from all  src/lib.rs  and test files
  across the repository.
  • Replaced deprecated  Env::register_contract  with  Env::register  in test
  utilities ( account.rs ,  token.rs ).
  • Replaced nearly 40 occurrences of the deprecated  token::Client  alias
  with the recommended  token::TokenClient  across all contracts and examples.
  • Added an explanatory comment to the narrow  #[allow(deprecated)]  block
  around  register_contract_wasm  in  backend/src/services/sandbox.rs ,
  justifying its necessity for dynamically executing arbitrary WASM blobs.

  Design Decisions & Notes

  • I opted to remove the deprecated pragmas from the unlinked backup folders
  (e.g.  examples/counter copy/ ) rather than deleting the folders outright,
  to strictly adhere to the issue scope.
  • Security Note: This PR is a strict refactor of test utility APIs and lints.
  No structural or business logic changes were made.

  Acceptance Criteria Checklist

  [✓] Deprecation warnings are visible by default.
  [✓] Any remaining deprecated usage is locally justified.