### PR TITLE
fix: resolve duplicate config imports and add backend check to CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -22,4 +22,4 @@ jobs:
 
       - name: Verify backend
         run: |
-          echo "Backend files verified and minimal backend check passed successfully!"
+          cargo check -p backend

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -8,7 +8,7 @@
 //! - [`AppConfig`] — hot-reloadable runtime configuration, loaded via the layered config crate.
 //! - [`reload`] — [`ConfigManager`] and Axum handlers for live config updates.
 
-use config::{Config, Environment as ConfigEnvironment, File, FileFormat};
+use config::{Config as ConfigBuilder, Environment as ConfigEnvironment, File, FileFormat};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -30,8 +30,6 @@ pub use observability::ObservabilityConfig;
 pub use redis::RedisConfig;
 pub use server::ServerConfig;
 
-use config::{Config as ConfigBuilder, Environment as ConfigEnvironment, File, FileFormat};
-use serde::{Deserialize, Serialize};
 
 /// The execution environment of the application.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]


### PR DESCRIPTION
# Closes #566                                                                                                      
                                                                                                                     
   **Summary:**                                                                                                     
   Cleaned up duplicate imports in the backend configuration module and enabled proper CI checks.                   
                                                                                                                     
   **Changes:**                                                                                                     
   - Removed redundant `config` and `serde` imports in `backend/src/config/mod.rs`.
   - Unified the external `config::Config` builder alias to `ConfigBuilder`.
   - Replaced the stubbed "Verify backend" step in `.github/workflows/backend-ci.yml` with the actual `cargo check -
  p backend` command.
  
   **Acceptance Criteria Checklist:**
   - [x] Config module imports are unambiguous.
   - [x] Backend config code compiles cleanly.
  
   **Testing:**
   - Verified locally that `cargo check -p backend` and `cargo test -p backend config::` compile and pass.          
   - Verified the CI workflow change is scoped only to what's needed.
  
   **Security:** 
    No changes to secret handling or loaded environments.