### PR TITLE
Standardize test auth setup on mock_all_auths/mock_auths

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ let bob   = env.account("bob");
 // Use the address wherever Soroban expects one
 client.transfer(&alice.address(), &bob.address(), &100_i128);
 
-// Sign authorization for a call
-env.set_auths(&[alice.auth()]);
+// Authorize protected calls in tests
+env.mock_all_auths();
 client.some_protected_call(&alice.address());
 ```
 
@@ -238,10 +238,14 @@ The `AccountHandle` type gives you:
 | Method | Returns | Description |
 |---|---|---|
 | `.address()` | `Address` | The Soroban address for this account |
-| `.auth()` | `InvokerContractAuthEntry` | Authorization entry for use with `set_auths` |
 | `.xlm_balance()` | `i128` | Current XLM balance in stroops |
 | `.token_balance(&token)` | `i128` | Balance in a given `MockToken` |
 | `.sign(payload)` | `Vec<u8>` | Sign an arbitrary payload with the account keypair |
+
+Authorization in tests is driven through the environment, not the account handle.
+Call `env.mock_all_auths()` to let every `require_auth()` succeed (the common
+happy-path style used throughout these examples), or `env.mock_auths(&[])` to
+clear authorizations so a protected call is expected to fail.
 
 ---
 
@@ -438,7 +442,7 @@ impl AmmFixture {
         let pool_client = AmmPoolClient::new(&env.inner(), &env.contract_id::<AmmPool>());
         xlm.mint(&alice.address(), 10_000_000);
         usdc.mint(&alice.address(), 10_000_000);
-        env.set_auths(&[alice.auth()]);
+        env.mock_all_auths();
         pool_client.add_liquidity(&xlm.address(), &usdc.address(), &10_000_000_i128, &10_000_000_i128);
 
         Self { env, pool: env.contract_id::<AmmPool>(), xlm, usdc, alice, bob }
@@ -633,7 +637,7 @@ mod token_tests {
             let bob    = env.account("bob");
             let client = MyTokenContractClient::new(&env.inner(), &env.contract_id::<MyTokenContract>());
 
-            env.set_auths(&[admin.auth()]);
+            env.mock_all_auths();
             client.initialize(&admin.address(), &7_u32, &"My Token".into(), &"MTK".into());
 
             Self { env, client, admin, alice, bob }
@@ -644,7 +648,6 @@ mod token_tests {
     fn test_mint_emits_event_and_updates_balance() {
         let f = TokenFixture::setup();
 
-        f.env.set_auths(&[f.admin.auth()]);
         f.client.mint(&f.alice.address(), &1_000_i128);
 
         assert_eq!(f.client.balance(&f.alice.address()), 1_000_i128);
@@ -660,10 +663,7 @@ mod token_tests {
     fn test_transfer_moves_balance_between_accounts() {
         let f = TokenFixture::setup();
 
-        f.env.set_auths(&[f.admin.auth()]);
         f.client.mint(&f.alice.address(), &500_i128);
-
-        f.env.set_auths(&[f.alice.auth()]);
         f.client.transfer(&f.alice.address(), &f.bob.address(), &200_i128);
 
         assert_eq!(f.client.balance(&f.alice.address()), 300_i128);
@@ -684,10 +684,10 @@ mod token_tests {
     fn test_transfer_without_auth_reverts() {
         let f = TokenFixture::setup();
 
-        f.env.set_auths(&[f.admin.auth()]);
         f.client.mint(&f.alice.address(), &500_i128);
 
-        // No auth set — should revert
+        // Clear mocked auth so require_auth() is enforced — should revert
+        f.env.mock_auths(&[]);
         assert_reverts!(
             f.client.transfer(&f.alice.address(), &f.bob.address(), &200_i128)
         );
@@ -723,7 +723,7 @@ fn test_escrow_full_lifecycle() {
 
     // 1. Buyer creates escrow
     xlm.mint(&buyer.address(), 10_000_i128);
-    env.set_auths(&[buyer.auth()]);
+    env.mock_all_auths();
     let escrow_id = client.create(
         &buyer.address(),
         &seller.address(),
@@ -738,10 +738,7 @@ fn test_escrow_full_lifecycle() {
     env.advance_time(Duration::days(3));
 
     // 3. Seller claims — arbiter approves
-    env.set_auths(&[arbiter.auth()]);
     client.approve(&escrow_id);
-
-    env.set_auths(&[seller.auth()]);
     client.claim(&escrow_id, &seller.address());
 
     assert_eq!(xlm.balance(&seller.address()), 10_000_i128);
@@ -773,8 +770,9 @@ fn test_vesting_cliff_is_enforced() {
     xlm.mint(&env.contract_id::<VestingContract>(), 100_000_i128);
     client.initialize(&beneficiary.address(), &cliff_seconds, &100_000_i128);
 
+    env.mock_all_auths();
+
     // Attempt to claim before cliff — must fail
-    env.set_auths(&[beneficiary.auth()]);
     assert_reverts!(client.claim());
 
     // Advance to just before cliff
@@ -819,7 +817,7 @@ fn test_aggregator_calls_multiple_pools() {
 
     let agg_client = AggregatorClient::new(&env.inner(), &env.contract_id::<Aggregator>());
 
-    env.set_auths(&[trader.auth()]);
+    env.mock_all_auths();
     let out_amount = agg_client.best_swap(
         &xlm.address(),
         &usdc.address(),

--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -200,6 +200,16 @@ impl MockEnv {
         self.inner.mock_all_auths();
     }
 
+    /// Set explicit mock authorizations for subsequent contract calls.
+    ///
+    /// Unlike [`mock_all_auths`](Self::mock_all_auths), this authorizes only the
+    /// invocations described by the supplied entries. Passing an empty slice
+    /// clears all mocked authorizations so that `require_auth()` calls fail —
+    /// useful for negative authorization tests.
+    pub fn mock_auths(&self, auths: &[soroban_sdk::testutils::MockAuth<'_>]) {
+        self.inner.mock_auths(auths);
+    }
+
     /// Advance the ledger timestamp by a duration.
     pub fn advance_time(&self, duration: Duration) {
         let info = self.inner.ledger().get();

--- a/contracts/supply_chain/tests/supply_chain_test.rs
+++ b/contracts/supply_chain/tests/supply_chain_test.rs
@@ -15,7 +15,8 @@ mod tests {
 
     #[test]
     fn test_item_creation_and_query() {
-        let mut env = setup_env();
+        let env = setup_env();
+        env.mock_all_auths();
         // metadata: simple key/value
         let mut meta = Map::<Symbol, RawVal>::new(&env);
         meta.set(&symbol_short!("sku"), &RawVal::from_val(&env, &"ABC123"));
@@ -29,7 +30,8 @@ mod tests {
 
     #[test]
     fn test_status_update_authorized() {
-        let mut env = setup_env();
+        let env = setup_env();
+        env.mock_all_auths();
         let id = SupplyChain::create_item(&env, Map::new(&env));
         // alice is current holder
         SupplyChain::update_status(&env, id, Status::InTransit);
@@ -39,16 +41,18 @@ mod tests {
 
     #[test]
     fn test_status_update_unauthorized() {
-        let mut env = setup_env();
+        let env = setup_env();
+        env.mock_all_auths();
         let id = SupplyChain::create_item(&env, Map::new(&env));
-        // switch auth to bob
-        env.set_auths(&[env.account("bob").auth()]);
+        // clear auth so the holder's require_auth() is enforced and fails
+        env.mock_auths(&[]);
         assert_reverts!(SupplyChain::update_status(&env, id, Status::InTransit));
     }
 
     #[test]
     fn test_transfer_holder() {
-        let mut env = setup_env();
+        let env = setup_env();
+        env.mock_all_auths();
         let id = SupplyChain::create_item(&env, Map::new(&env));
         let bob_addr = env.account("bob").address();
         SupplyChain::transfer_holder(&env, id, bob_addr.clone());
@@ -58,10 +62,11 @@ mod tests {
 
     #[test]
     fn test_transfer_unauthorized() {
-        let mut env = setup_env();
+        let env = setup_env();
+        env.mock_all_auths();
         let id = SupplyChain::create_item(&env, Map::new(&env));
-        // bob tries to transfer
-        env.set_auths(&[env.account("bob").auth()]);
+        // clear auth so the holder's require_auth() is enforced and fails
+        env.mock_auths(&[]);
         let bob_addr = env.account("bob").address();
         assert_reverts!(SupplyChain::transfer_holder(&env, id, bob_addr));
     }


### PR DESCRIPTION
Closes #538

### Problem
The README and the `supply_chain` integration test referenced `env.set_auths(&[alice.auth()])` and `AccountHandle::auth()` (documented as returning `InvokerContractAuthEntry`). Neither API exists on `MockEnv`/`AccountHandle`, so the public examples referenced missing auth APIs and used an auth style inconsistent with the rest of the codebase.

### Decision
A faithful `set_auths(&[address.auth()])` is not implementable with the Soroban SDK: an authorization entry requires the full invocation tree (contract + function + args), not just an address. There is no SDK primitive for "authorize this address for anything" other than `mock_all_auths`. Every actual workspace example crate already standardizes on `env.mock_all_auths()`, and the crate's own `reputation.rs` doc comment already points users to `MockEnv::mock_auths` for granular/negative auth tests.

Accordingly, this PR removes the unsupported API from all public examples and standardizes on the supported SDK pattern, while exposing the granular `mock_auths` wrapper the docs already assumed.

### Changes
- **`contracts/crucible/src/env.rs`**: Add `MockEnv::mock_auths(&[MockAuth])`, a thin wrapper over `soroban_sdk::Env::mock_auths`. Passing an empty slice clears mocked authorizations so `require_auth()` is enforced — the supported way to write negative-auth tests.
- **`README.md`**: Replace all `env.set_auths(&[x.auth()])` calls with `env.mock_all_auths()`; drop the `.auth()` row from the `AccountHandle` table; rewrite the "transfer without auth reverts" example to clear auth via `env.mock_auths(&[])`; add a short note describing the auth model.
- **`contracts/supply_chain/tests/supply_chain_test.rs`**: Apply the same consistent style — protected/happy-path calls use `mock_all_auths()`, unauthorized cases use `mock_auths(&[])`.

### Acceptance criteria
- Public examples no longer reference missing auth APIs (`set_auths`/`.auth()` fully removed).
- Protected-call examples use one consistent auth setup style: `mock_all_auths()` for happy paths and `mock_auths(&[])` for negative authorization checks.
