### PR TITLE
fix(snapshots): fail on missing snapshots instead of writing files si…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,22 @@ cargo doc --workspace --no-deps --all-features --open
 
 text
 
+## Cost Snapshots
+
+Cost snapshots capture instruction and memory metrics for contract invocations and live in `test_snapshots/cost/` next to the crate under test.
+
+**Normal test runs** — if a snapshot file is missing, the test fails immediately with a message pointing to the missing path. No files are written. This keeps CI and contributor working trees clean.
+
+**Creating or updating snapshots** — set `CRUCIBLE_UPDATE_SNAPSHOTS=1` before running tests:
+
+```sh
+CRUCIBLE_UPDATE_SNAPSHOTS=1 cargo test -p crucible --features snapshots
+```
+
+This writes (or overwrites) every snapshot that is exercised during the run. Review the diff with `git diff` and commit the updated files alongside your code change.
+
+**Accepting a regression** — if an intentional cost increase exceeds the 5 % default tolerance, re-run with `CRUCIBLE_UPDATE_SNAPSHOTS=1` to record the new baseline, then commit both the code and the updated snapshot.
+
 ## Pull Request Process
 
 1. Fork and create a feature branch

--- a/contracts/crucible/src/cost.rs
+++ b/contracts/crucible/src/cost.rs
@@ -142,7 +142,18 @@ impl CostReport {
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
 
-        if !snap_path.exists() || update {
+        if !snap_path.exists() {
+            if !update {
+                panic!(
+                    "missing cost snapshot '{}' at {}\n\
+                     Run with CRUCIBLE_UPDATE_SNAPSHOTS=1 to create it.",
+                    name,
+                    snap_path.display()
+                );
+            }
+        }
+
+        if update {
             fs::create_dir_all(&snap_dir)
                 .unwrap_or_else(|e| panic!("failed to create snapshot dir: {}", e));
 
@@ -157,11 +168,7 @@ impl CostReport {
             fs::write(&snap_path, json)
                 .unwrap_or_else(|e| panic!("failed to write snapshot: {}", e));
 
-            if update {
-                eprintln!("[crucible] updated snapshot '{}'", name);
-            } else {
-                eprintln!("[crucible] wrote new snapshot '{}'", name);
-            }
+            eprintln!("[crucible] updated snapshot '{}'", name);
             return;
         }
 


### PR DESCRIPTION
…lently

Missing cost snapshots now panic with an actionable message rather than writing a baseline file, keeping normal test runs and CI workspaces clean. Set CRUCIBLE_UPDATE_SNAPSHOTS=1 to create or refresh snapshots explicitly.

Closes #550