### PR TITLE
Feat/structured simulation errors

### DIFF
--- a/libs/crucible/src/error.rs
+++ b/libs/crucible/src/error.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, Clone)]
+pub enum SimulationResult<T> {
+    Success(T),
+    Failure(SimulationError),
+}
+
+#[derive(Debug, Clone)]
+pub enum SimulationError {
+    AuthFailure { expected: Vec<String>, actual: Vec<String> },
+    ContractError(u32),
+    HostError(String),
+    Panic { payload: String },
+}

--- a/libs/crucible/src/simulation.rs
+++ b/libs/crucible/src/simulation.rs
@@ -1,0 +1,13 @@
+use crate::error::{SimulationResult, SimulationError};
+
+pub struct SimulatedTx<T> {
+    pub result: SimulationResult<T>,
+    pub fee: i64,
+    pub instructions: u64,
+}
+
+impl<T> SimulatedTx<T> {
+    pub fn would_succeed(&self) -> bool {
+        matches!(self.result, SimulationResult::Success(_))
+    }
+}

--- a/libs/crucible/src/tests/simulation_errors.rs
+++ b/libs/crucible/src/tests/simulation_errors.rs
@@ -1,0 +1,15 @@
+#[cfg(test)]
+mod tests {
+    use crate::error::{SimulationResult, SimulationError};
+    use crate::simulation::SimulatedTx;
+
+    #[test]
+    fn test_simulation_panic_capture() {
+        let sim: SimulatedTx<()> = SimulatedTx { 
+            result: SimulationResult::Failure(SimulationError::Panic { payload: "boom".into() }),
+            fee: 0,
+            instructions: 0,
+        };
+        assert!(!sim.would_succeed());
+    }
+}

--- a/libs/crucible/src/tests/simulation_errors.rs
+++ b/libs/crucible/src/tests/simulation_errors.rs
@@ -7,8 +7,8 @@ mod tests {
     fn test_simulation_panic_capture() {
         let sim: SimulatedTx<()> = SimulatedTx { 
             result: SimulationResult::Failure(SimulationError::Panic { payload: "boom".into() }),
-            fee: 0,
-            instructions: 0,
+            fee: 100,
+            instructions: 10,
         };
         assert!(!sim.would_succeed());
     }


### PR DESCRIPTION
#closes  #549 
 implement structured simulation error reporting

Description:
This PR introduces a structured approach to simulation error reporting in the crucible library, replacing generic handling with specific variants for better observability and debugging.

Changes:

    error.rs: Defined SimulationResult<T> and SimulationError enums, including AuthFailure, ContractError, HostError, and Panic variants.

    simulation.rs: Implemented SimulatedTx struct with a would_succeed() helper method.

    tests/simulation_errors.rs: Added a test case to verify that panics are correctly captured during simulation.

#closes