### PR TITLE
Add thread-safety documentation and compile-time assertions for MockEnv (Send/Sync)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ edition = "2021"
 [workspace.dependencies]
 soroban-sdk = { version = "26", features = ["testutils"] }
 crucible-macros = { path = "crucible-macros" }
+[dev-dependencies]
+static_assertions = "*"

--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -108,6 +108,7 @@ impl Stroops {
     }
 }
 
+/// **Thread‑safety:** `MockEnv` is deliberately single‑threaded; it uses `Rc`/`RefCell` and does **not** implement `Send` or `Sync`. This ensures deterministic behavior in tests but means fixtures cannot be moved across async tasks.
 /// A wrapper around the Soroban test environment with additional helpers.
 #[derive(Clone)]
 pub struct MockEnv {
@@ -464,8 +465,13 @@ impl std::fmt::Debug for MockEnv {
             )
             .field("track_costs", &self.track_costs)
             .finish_non_exhaustive()
-    }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Ensure MockEnv does NOT implement Send or Sync.
+    static_assertions::assert_not_impl_any!(MockEnv: Send, Sync);
 }
+
 
 /// Builder for constructing a `MockEnv` with custom configuration.
 pub struct MockEnvBuilder {


### PR DESCRIPTION
This PR closes #543 
summary:

Added clear documentation that MockEnv is intentionally single‑threaded and does not implement Send or Sync.
Included a compile‑time static assertion (assert_not_impl_any!(MockEnv: Send, Sync)) to enforce this behavior.
Added static_assertions as a dev‑dependency in Cargo.toml.
Updated README to reflect the thread‑safety guarantees.