### PR TITLE
feat: add scoped mock auth API to prevent auth bypass leaking between tests (#537)

### DIFF
--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -323,9 +323,53 @@ impl MockEnv {
 
     /// Enable mock authorization for all calls.
     ///
-    /// This causes all `require_auth()` calls to succeed without valid signatures.
+    /// The bypass persists until explicitly cleared. Prefer
+    /// [`with_mock_all_auths`] or [`mock_all_auths_scoped`] to contain the
+    /// bypass to a single block.
     pub fn mock_all_auths(&self) {
         self.inner.mock_all_auths();
+    }
+
+    /// Enable mock authorization for the duration of a closure, then clear it.
+    ///
+    /// After `f` returns, `mock_auths(&[])` is called so that subsequent
+    /// `require_auth()` calls are enforced normally.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// env.with_mock_all_auths(|| {
+    ///     contract.initialize(&admin);
+    /// });
+    /// // Auth required again from here on.
+    /// ```
+    pub fn with_mock_all_auths<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce() -> T,
+    {
+        self.inner.mock_all_auths();
+        let result = f();
+        self.inner.mock_auths(&[]);
+        result
+    }
+
+    /// Returns an RAII guard that enables mock authorization until dropped.
+    ///
+    /// Useful when the scoped block spans multiple statements that cannot
+    /// easily be wrapped in a single closure.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// {
+    ///     let _guard = env.mock_all_auths_scoped();
+    ///     contract.step_one();
+    ///     contract.step_two();
+    /// } // guard dropped — auth restored
+    /// ```
+    pub fn mock_all_auths_scoped(&self) -> MockAuthGuard {
+        self.inner.mock_all_auths();
+        MockAuthGuard {
+            env: self.inner.clone(),
+        }
     }
 
     /// Set explicit mock authorizations for subsequent contract calls.
@@ -674,6 +718,31 @@ impl MockEnv {
     }
 }
 
+/// RAII guard that clears mock auth when dropped.
+///
+/// Obtained via [`MockEnv::mock_all_auths_scoped`]. Auth bypass is active for
+/// as long as this value is alive; dropping it calls `mock_auths(&[])` on the
+/// underlying environment, restoring the requirement for real auth on all
+/// subsequent calls.
+///
+/// # Example
+/// ```rust,ignore
+/// {
+///     let _guard = env.mock_all_auths_scoped();
+///     contract.step_one();
+///     contract.step_two();
+/// } // _guard dropped — auth required again
+/// ```
+pub struct MockAuthGuard {
+    env: Env,
+}
+
+impl Drop for MockAuthGuard {
+    fn drop(&mut self) {
+        self.env.mock_auths(&[]);
+    }
+}
+
 impl Default for MockEnv {
     fn default() -> Self {
         Self {
@@ -709,6 +778,9 @@ impl std::fmt::Debug for MockEnv {
             )
             .field("track_costs", &self.track_costs)
             .finish_non_exhaustive()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -960,5 +1032,49 @@ mod tests {
 
         let alice = env2.account("alice");
         assert_eq!(alice.xlm_balance(), Stroops::xlm(100).as_stroops());
+    }
+}
+
+#[cfg(test)]
+mod auth_scope_tests {
+    use super::*;
+
+    #[test]
+    fn with_mock_all_auths_clears_after_block() {
+        let env = MockEnv::default();
+        env.with_mock_all_auths(|| {
+            // no contract calls needed — just verify the side-effect
+        });
+        // mock_auths(&[]) must have been called; auths() should be empty
+        let auths = env.inner().auths();
+        assert!(
+            auths.is_empty(),
+            "auth bypass must be cleared after with_mock_all_auths"
+        );
+    }
+
+    #[test]
+    fn scoped_guard_clears_on_drop() {
+        let env = MockEnv::default();
+        {
+            let _guard = env.mock_all_auths_scoped();
+        } // dropped here
+        let auths = env.inner().auths();
+        assert!(
+            auths.is_empty(),
+            "auth bypass must be cleared after guard drop"
+        );
+    }
+
+    #[test]
+    fn successive_scopes_do_not_interfere() {
+        let env = MockEnv::default();
+        {
+            let _g = env.mock_all_auths_scoped();
+        }
+        {
+            let _g = env.mock_all_auths_scoped();
+        }
+        assert!(env.inner().auths().is_empty());
     }
 }

--- a/contracts/crucible/src/prelude.rs
+++ b/contracts/crucible/src/prelude.rs
@@ -8,6 +8,7 @@ pub use crate::account::AccountHandle;
 pub use crate::cost::CostReport;
 pub use crate::env::CapturedEvent;
 pub use crate::env::Duration;
+pub use crate::env::MockAuthGuard;
 pub use crate::env::MockEnv;
 pub use crate::env::MockEnvBuilder;
 pub use crate::env::Stroops;

--- a/examples/emergency_stop/src/test.rs
+++ b/examples/emergency_stop/src/test.rs
@@ -33,8 +33,9 @@ impl Ctx {
         let guardian = env.account("guardian");
         let user = env.account("user");
 
-        env.mock_all_auths();
-        EmergencyStopClient::new(env.inner(), &id).initialize(&admin);
+        env.with_mock_all_auths(|| {
+            EmergencyStopClient::new(env.inner(), &id).initialize(&admin);
+        });
 
         Ctx {
             env,
@@ -63,26 +64,29 @@ fn test_initial_state_is_not_stopped() {
 #[test]
 fn test_admin_can_stop() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stop(&ctx.admin);
+    ctx.env.with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
     assert!(ctx.client().is_stopped());
 }
 
 #[test]
 fn test_admin_can_resume() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stop(&ctx.admin);
-    ctx.client().resume();
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        ctx.client().stop(&ctx.admin);
+        ctx.client().resume();
+    }
     assert!(!ctx.client().is_stopped());
 }
 
 #[test]
 fn test_guardian_can_stop() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().add_guardian(&ctx.guardian);
-    ctx.client().stop(&ctx.guardian);
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        ctx.client().add_guardian(&ctx.guardian);
+        ctx.client().stop(&ctx.guardian);
+    }
     assert!(ctx.client().is_stopped());
 }
 
@@ -96,8 +100,7 @@ fn test_non_guardian_cannot_stop() {
 #[test]
 fn test_double_stop_reverts() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stop(&ctx.admin);
+    ctx.env.with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
     assert_reverts!(ctx.client().stop(&ctx.admin), "already stopped");
 }
 
@@ -119,17 +122,18 @@ fn test_protected_action_succeeds_when_running() {
 #[test]
 fn test_protected_action_reverts_when_stopped() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stop(&ctx.admin);
+    ctx.env.with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
     assert_reverts!(ctx.client().protected_action(&ctx.user), "stopped");
 }
 
 #[test]
 fn test_protected_action_succeeds_after_resume() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stop(&ctx.admin);
-    ctx.client().resume();
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        ctx.client().stop(&ctx.admin);
+        ctx.client().resume();
+    }
     // Should not panic after resume.
     ctx.client().protected_action(&ctx.user);
 }
@@ -137,9 +141,11 @@ fn test_protected_action_succeeds_after_resume() {
 #[test]
 fn test_removed_guardian_cannot_stop() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().add_guardian(&ctx.guardian);
-    ctx.client().remove_guardian(&ctx.guardian);
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        ctx.client().add_guardian(&ctx.guardian);
+        ctx.client().remove_guardian(&ctx.guardian);
+    }
     assert_reverts!(ctx.client().stop(&ctx.guardian), "unauthorized");
 }
 
@@ -149,9 +155,11 @@ fn test_non_admin_cannot_add_guardian() {
     // by confirming they work with mock_all_auths and that removing a guardian
     // correctly revokes their ability to stop the contract.
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().add_guardian(&ctx.guardian);
-    ctx.client().remove_guardian(&ctx.guardian);
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        ctx.client().add_guardian(&ctx.guardian);
+        ctx.client().remove_guardian(&ctx.guardian);
+    }
     // After removal, the former guardian is no longer authorized to stop.
     assert_reverts!(ctx.client().stop(&ctx.guardian), "unauthorized");
 }
@@ -159,8 +167,7 @@ fn test_non_admin_cannot_add_guardian() {
 #[test]
 fn test_stop_emits_event() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stop(&ctx.admin);
+    ctx.env.with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
     assert_emitted!(
         ctx.env,
         ctx.id,
@@ -172,17 +179,18 @@ fn test_stop_emits_event() {
 #[test]
 fn test_resume_emits_event() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stop(&ctx.admin);
-    ctx.client().resume();
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        ctx.client().stop(&ctx.admin);
+        ctx.client().resume();
+    }
     assert_emitted!(ctx.env, ctx.id, (symbol_short!("resumed"),), ());
 }
 
 #[test]
 fn test_add_guardian_emits_event() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().add_guardian(&ctx.guardian);
+    ctx.env.with_mock_all_auths(|| ctx.client().add_guardian(&ctx.guardian));
     assert_emitted!(
         ctx.env,
         ctx.id,

--- a/examples/escrow/src/test.rs
+++ b/examples/escrow/src/test.rs
@@ -58,15 +58,16 @@ impl Ctx {
 
     /// Convenience: create a live escrow with unlock_time = BASE_TIME + LOCK_DURATION.
     fn create_escrow(&self) {
-        self.env.mock_all_auths();
-        self.client().create(
-            &self.depositor,
-            &self.recipient,
-            &self.arbiter,
-            &self.token.address(),
-            &AMOUNT,
-            &(BASE_TIME + LOCK_DURATION),
-        );
+        self.env.with_mock_all_auths(|| {
+            self.client().create(
+                &self.depositor,
+                &self.recipient,
+                &self.arbiter,
+                &self.token.address(),
+                &AMOUNT,
+                &(BASE_TIME + LOCK_DURATION),
+            );
+        });
     }
 }
 
@@ -92,8 +93,7 @@ fn test_claim_after_timeout() {
 
     // Advance past the time lock.
     ctx.env.advance_time(Duration::seconds(LOCK_DURATION + 1));
-    ctx.env.mock_all_auths();
-    ctx.client().claim();
+    ctx.env.with_mock_all_auths(|| ctx.client().claim());
 
     assert_eq!(ctx.token.balance(&ctx.recipient), AMOUNT);
     assert_eq!(ctx.token.balance(&ctx.id), 0);
@@ -116,8 +116,7 @@ fn test_arbiter_approve_allows_early_claim() {
     ctx.create_escrow();
 
     // Arbiter approves without waiting for the time lock.
-    ctx.env.mock_all_auths();
-    ctx.client().approve(&ctx.arbiter);
+    ctx.env.with_mock_all_auths(|| ctx.client().approve(&ctx.arbiter));
 
     // Recipient claims immediately.
     ctx.client().claim();
@@ -146,8 +145,7 @@ fn test_refund_after_timeout() {
 
     // Advance past the time lock.
     ctx.env.advance_time(Duration::seconds(LOCK_DURATION + 1));
-    ctx.env.mock_all_auths();
-    ctx.client().refund();
+    ctx.env.with_mock_all_auths(|| ctx.client().refund());
 
     // Depositor gets their tokens back.
     assert_eq!(ctx.token.balance(&ctx.depositor), AMOUNT * 2);
@@ -169,8 +167,7 @@ fn test_double_claim_reverts() {
     ctx.create_escrow();
 
     ctx.env.advance_time(Duration::seconds(LOCK_DURATION + 1));
-    ctx.env.mock_all_auths();
-    ctx.client().claim();
+    ctx.env.with_mock_all_auths(|| ctx.client().claim());
 
     // Second claim should revert.
     assert_reverts!(ctx.client().claim(), "already settled");
@@ -179,14 +176,15 @@ fn test_double_claim_reverts() {
 #[test]
 fn test_create_emits_event() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().create(
-        &ctx.depositor,
-        &ctx.recipient,
-        &ctx.arbiter,
-        &ctx.token.address(),
-        &AMOUNT,
-        &(BASE_TIME + LOCK_DURATION),
-    );
+    ctx.env.with_mock_all_auths(|| {
+        ctx.client().create(
+            &ctx.depositor,
+            &ctx.recipient,
+            &ctx.arbiter,
+            &ctx.token.address(),
+            &AMOUNT,
+            &(BASE_TIME + LOCK_DURATION),
+        );
+    });
     assert_emitted!(ctx.env, ctx.id, (symbol_short!("created"),), AMOUNT);
 }

--- a/examples/staking/src/test.rs
+++ b/examples/staking/src/test.rs
@@ -39,8 +39,9 @@ impl Ctx {
         token.mint(&alice, STAKE_AMOUNT * 3);
         token.mint(&bob, STAKE_AMOUNT * 3);
 
-        env.mock_all_auths();
-        StakingClient::new(env.inner(), &id).initialize(&alice, &token.address());
+        env.with_mock_all_auths(|| {
+            StakingClient::new(env.inner(), &id).initialize(&alice, &token.address());
+        });
 
         Ctx {
             env,
@@ -64,8 +65,7 @@ impl Ctx {
 #[test]
 fn test_stake_transfers_tokens_to_contract() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None));
 
     assert_eq!(ctx.token.balance(&ctx.id), STAKE_AMOUNT);
     assert_eq!(ctx.token.balance(&ctx.alice), STAKE_AMOUNT * 2);
@@ -74,8 +74,7 @@ fn test_stake_transfers_tokens_to_contract() {
 #[test]
 fn test_stake_self_delegation_by_default() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None));
 
     // Without explicit delegate, voting power goes to self.
     assert_eq!(ctx.client().voting_power(&ctx.alice), STAKE_AMOUNT);
@@ -95,8 +94,7 @@ fn test_stake_with_explicit_delegate() {
 #[test]
 fn test_delegate_changes_voting_power() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None));
 
     // Alice delegates to Bob.
     ctx.client().delegate(&ctx.alice, &ctx.bob);
@@ -108,10 +106,12 @@ fn test_delegate_changes_voting_power() {
 #[test]
 fn test_delegate_then_redelegate() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
-    ctx.client().delegate(&ctx.alice, &ctx.bob);
-    ctx.client().delegate(&ctx.alice, &ctx.charlie);
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+        ctx.client().delegate(&ctx.alice, &ctx.bob);
+        ctx.client().delegate(&ctx.alice, &ctx.charlie);
+    }
 
     assert_eq!(ctx.client().voting_power(&ctx.alice), 0);
     assert_eq!(ctx.client().voting_power(&ctx.bob), 0);
@@ -121,8 +121,7 @@ fn test_delegate_then_redelegate() {
 #[test]
 fn test_unstake_returns_tokens() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None));
     ctx.client().unstake(&ctx.alice);
 
     assert_eq!(ctx.token.balance(&ctx.alice), STAKE_AMOUNT * 3);
@@ -132,8 +131,7 @@ fn test_unstake_returns_tokens() {
 #[test]
 fn test_unstake_removes_voting_power() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None));
     ctx.client().unstake(&ctx.alice);
 
     assert_eq!(ctx.client().voting_power(&ctx.alice), 0);
@@ -153,12 +151,14 @@ fn test_unstake_removes_delegated_voting_power() {
 #[test]
 fn test_multiple_stakers_accumulate_voting_power() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    // Both alice and bob delegate to charlie.
-    ctx.client()
-        .stake(&ctx.alice, &STAKE_AMOUNT, &Some(ctx.charlie.clone()));
-    ctx.client()
-        .stake(&ctx.bob, &STAKE_AMOUNT, &Some(ctx.charlie.clone()));
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        // Both alice and bob delegate to charlie.
+        ctx.client()
+            .stake(&ctx.alice, &STAKE_AMOUNT, &Some(ctx.charlie.clone()));
+        ctx.client()
+            .stake(&ctx.bob, &STAKE_AMOUNT, &Some(ctx.charlie.clone()));
+    }
 
     assert_eq!(ctx.client().voting_power(&ctx.charlie), STAKE_AMOUNT * 2);
 }
@@ -190,8 +190,7 @@ fn test_delegate_without_stake_reverts() {
 #[test]
 fn test_stake_emits_event() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None));
     // Verify the staked event is present (alongside the SAC transfer event).
     let matching = ctx
         .env
@@ -202,9 +201,11 @@ fn test_stake_emits_event() {
 #[test]
 fn test_unstake_emits_event() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
-    ctx.client().unstake(&ctx.alice);
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+        ctx.client().unstake(&ctx.alice);
+    }
     let matching = ctx
         .env
         .events_matching((soroban_sdk::symbol_short!("unstaked"),));
@@ -217,9 +218,11 @@ fn test_unstake_emits_event() {
 #[test]
 fn test_delegate_emits_event() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
-    ctx.client().delegate(&ctx.alice, &ctx.bob);
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+        ctx.client().delegate(&ctx.alice, &ctx.bob);
+    }
     let matching = ctx
         .env
         .events_matching((soroban_sdk::symbol_short!("delegated"),));
@@ -232,9 +235,10 @@ fn test_delegate_emits_event() {
 #[test]
 fn test_get_stake_returns_correct_info() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client()
-        .stake(&ctx.alice, &STAKE_AMOUNT, &Some(ctx.bob.clone()));
+    ctx.env.with_mock_all_auths(|| {
+        ctx.client()
+            .stake(&ctx.alice, &STAKE_AMOUNT, &Some(ctx.bob.clone()));
+    });
 
     let info = ctx.client().get_stake(&ctx.alice);
     assert_eq!(info.amount, STAKE_AMOUNT);
@@ -252,9 +256,11 @@ fn test_get_stake_returns_zero_for_unknown() {
 #[test]
 fn test_additional_stake_accumulates() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
-    ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+    {
+        let _auth = ctx.env.mock_all_auths_scoped();
+        ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+        ctx.client().stake(&ctx.alice, &STAKE_AMOUNT, &None);
+    }
 
     let info = ctx.client().get_stake(&ctx.alice);
     assert_eq!(info.amount, STAKE_AMOUNT * 2);


### PR DESCRIPTION
## Summary

Closes #537

`env.mock_all_auths()` had no scoping mechanism — once called, the auth
bypass persisted for the rest of the test, silently permitting protected
calls that should have failed.

## New API

Three-tier API so existing code is not broken:

| API | Use when |
|---|---|
| `env.mock_all_auths()` | Whole-test bypass (unchanged, backward compatible) |
| `env.with_mock_all_auths(\|\| { ... })` | Single operation or tight group |
| `env.mock_all_auths_scoped()` | Multi-statement block where a closure is awkward |

Both new methods call `mock_auths(&[])` on exit — the closure variant
after it returns, the RAII guard in its `Drop` impl.

## Files Changed

**`contracts/crucible/src/env.rs`**
- Added `MockAuthGuard` RAII struct with `Drop` calling `mock_auths(&[])`
- Added `with_mock_all_auths<F, T>(&self, f: F) -> T`
- Added `mock_all_auths_scoped(&self) -> MockAuthGuard`
- Added `auth_scope_tests` module with 3 regression tests

**`contracts/crucible/src/prelude.rs`**
- Re-exported `MockAuthGuard` so callers using `crucible::prelude::*` get it automatically

**`examples/escrow/src/test.rs`**
- `create_escrow` helper: bare `mock_all_auths()` → `with_mock_all_auths`
- Per-test single calls converted to `with_mock_all_auths`

**`examples/staking/src/test.rs`**
- `setup()` initialize call scoped with `with_mock_all_auths`
- Multi-call blocks use `mock_all_auths_scoped` guard

**`examples/emergency_stop/src/test.rs`**
- `setup()` initialize call scoped with `with_mock_all_auths`
- Multi-call blocks use `mock_all_auths_scoped` guard

## Regression Tests Added

- `with_mock_all_auths_clears_after_block` — asserts `auths()` is empty after closure returns
- `scoped_guard_clears_on_drop` — asserts `auths()` is empty after guard is dropped
- `successive_scopes_do_not_interfere` — two back-to-back scopes both clean up correctly