### PR TITLE
feat(security): add audit log tamper protection hashes with SHA-256 chaining (#743)

### DIFF
--- a/backend/migrations/20260528000000_audit_logs.sql
+++ b/backend/migrations/20260528000000_audit_logs.sql
@@ -1,8 +1,13 @@
--- Add audit_logs table for audit logging service
+-- Add audit_logs table for audit logging service with hash chain tamper protection
 CREATE TABLE IF NOT EXISTS audit_logs (
     id SERIAL PRIMARY KEY,
     event_type TEXT NOT NULL,
     user_id TEXT,
     details JSONB NOT NULL,
-    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    hash TEXT NOT NULL DEFAULT '',
+    previous_hash TEXT NOT NULL DEFAULT ''
 );
+
+-- Index for chain verification queries (ordered by id for linear chain walk)
+CREATE INDEX IF NOT EXISTS idx_audit_logs_id_asc ON audit_logs (id ASC);

--- a/backend/src/services/audit.rs
+++ b/backend/src/services/audit.rs
@@ -1,4 +1,13 @@
 //! CQRS and Event Sourcing Architecture for Audit Logging Service.
+//!
+//! Audit entries are cryptographically hash-chained using SHA-256 to provide
+//! tamper detection.  Each entry stores ``previous_hash`` (the hash of the
+//! preceding entry in the chain) and its own ``hash`` computed as::
+//!
+//!     hash = SHA-256(previous_hash || serialized_entry)
+//!
+//! Use :meth:`AuditService.verify_chain` to detect unauthorized insertion,
+//! deletion, or modification of any entry in the chain.
 
 use axum::{
     extract::{Path, Query, State},
@@ -8,6 +17,7 @@ use axum::{
 };
 use redis::AsyncCommands;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -22,6 +32,9 @@ use crate::error::AppError;
 // ---------------------------------------------------------------------------
 
 /// Immutable domain event representing an audited action.
+///
+/// Each event carries a ``hash`` and ``previous_hash`` forming a SHA-256 chain
+/// that can be verified with :meth:`AuditService.verify_chain`.
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct AuditDomainEvent {
     pub event_id: Uuid,
@@ -31,6 +44,10 @@ pub struct AuditDomainEvent {
     pub details: serde_json::Value,
     pub sequence_number: u64,
     pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// SHA-256 hash of the serialized canonical representation.
+    pub hash: String,
+    /// Hash of the preceding event in the chain, or empty string for genesis.
+    pub previous_hash: String,
 }
 
 /// Command payload for recording a new audit event.
@@ -40,6 +57,34 @@ pub struct AuditEventRequest {
     pub event_type: String,
     pub user_id: Option<String>,
     pub details: serde_json::Value,
+}
+
+/// The canonical data that gets hashed for chain verification.
+/// Only fields that define the audit entry are included — metadata
+/// like `event_id` and `sequence_number` is excluded so that
+/// re-computation across replicas yields the same hash.
+#[derive(Debug, Serialize, Deserialize)]
+struct CanonicalAuditData<'a> {
+    previous_hash: &'a str,
+    event_type: &'a str,
+    user_id: Option<&'a str>,
+    details: &'a serde_json::Value,
+    timestamp: &'a chrono::DateTime<chrono::Utc>,
+}
+
+pub fn compute_hash(previous_hash: &str, event: &AuditDomainEvent) -> String {
+    let canonical = CanonicalAuditData {
+        previous_hash,
+        event_type: &event.event_type,
+        user_id: event.user_id.as_deref(),
+        details: &event.details,
+        timestamp: &event.timestamp,
+    };
+    let json = serde_json::to_string(&canonical).unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(json.as_bytes());
+    let result = hasher.finalize();
+    format!("{:x}", result)
 }
 
 // ---------------------------------------------------------------------------
@@ -53,6 +98,8 @@ pub struct AuditEventRecord {
     pub user_id: Option<String>,
     pub details: serde_json::Value,
     pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub hash: String,
+    pub previous_hash: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
@@ -64,6 +111,8 @@ pub struct AuditProjection {
     pub details: serde_json::Value,
     pub sequence_number: u64,
     pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub hash: String,
+    pub previous_hash: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -100,22 +149,47 @@ impl AuditService {
     }
 
     /// Event Sourcing Write Path: Appends event to event stream without blocking on DB read-table locks.
+    ///
+    /// Computes the SHA-256 hash chain:
+    /// 1. Reads the ``audit:last_hash`` key from Redis (previous hash).
+    /// 2. Computes ``hash = SHA-256(previous_hash || canonical_json)``.
+    /// 3. Writes the new hash back to ``audit:last_hash``.
+    /// 4. Publishes the event (with hash fields) to the event stream.
     pub async fn log_event(&self, req: AuditEventRequest) -> Result<Uuid, AppError> {
         let event_id = Uuid::new_v4();
         let aggregate_id = req.aggregate_id.unwrap_or_else(|| Uuid::new_v4().to_string());
+        let now = chrono::Utc::now();
 
-        let domain_event = AuditDomainEvent {
+        let mut conn = self.redis.get_multiplexed_async_connection().await.map_err(AppError::Redis)?;
+
+        // Retrieve the previous hash from Redis (empty string for genesis).
+        let previous_hash: String = conn
+            .get("audit:last_hash")
+            .await
+            .unwrap_or_default();
+
+        let mut domain_event = AuditDomainEvent {
             event_id,
             aggregate_id,
             event_type: req.event_type,
             user_id: req.user_id,
             details: req.details,
-            sequence_number: chrono::Utc::now().timestamp_millis() as u64,
-            timestamp: chrono::Utc::now(),
+            sequence_number: now.timestamp_millis() as u64,
+            timestamp: now,
+            hash: String::new(),
+            previous_hash: previous_hash.clone(),
         };
 
+        // Compute chain hash = SHA-256(previous_hash || canonical_data)
+        domain_event.hash = compute_hash(&previous_hash, &domain_event);
+
+        // Store the new hash as the chain tip for the next event.
+        let _: () = conn
+            .set("audit:last_hash", &domain_event.hash)
+            .await
+            .map_err(AppError::Redis)?;
+
         // Publish to Redis Event Stream
-        let mut conn = self.redis.get_multiplexed_async_connection().await.map_err(AppError::Redis)?;
         let event_json = serde_json::to_string(&domain_event).map_err(AppError::Serialization)?;
         let _: () = conn
             .lpush::<_, _, ()>("audit_event_stream", event_json)
@@ -137,12 +211,14 @@ impl AuditService {
         info!(event_id = %event.event_id, event_type = %event.event_type, "Projecting audit event");
 
         sqlx::query(
-            "INSERT INTO audit_logs (event_type, user_id, details, timestamp) VALUES ($1, $2, $3, $4)",
+            "INSERT INTO audit_logs (event_type, user_id, details, timestamp, hash, previous_hash) VALUES ($1, $2, $3, $4, $5, $6)",
         )
         .bind(&event.event_type)
         .bind(&event.user_id)
         .bind(&event.details)
         .bind(event.timestamp)
+        .bind(&event.hash)
+        .bind(&event.previous_hash)
         .execute(db)
         .await
         .map_err(AppError::Database)?;
@@ -157,10 +233,10 @@ impl AuditService {
         limit: u32,
     ) -> Result<Vec<AuditEventRecord>, AppError> {
         let limit = limit.clamp(1, 200) as i64;
+        let cols = "id, event_type, user_id, details, timestamp, hash, previous_hash";
         let rows = if let Some(event_type) = event_type {
             sqlx::query_as(
-                "SELECT id, event_type, user_id, details, timestamp FROM audit_logs
-                 WHERE event_type = $1 ORDER BY timestamp DESC LIMIT $2",
+                &format!("SELECT {cols} FROM audit_logs WHERE event_type = $1 ORDER BY timestamp DESC LIMIT $2"),
             )
             .bind(event_type)
             .bind(limit)
@@ -168,8 +244,7 @@ impl AuditService {
             .await?
         } else {
             sqlx::query_as(
-                "SELECT id, event_type, user_id, details, timestamp FROM audit_logs
-                 ORDER BY timestamp DESC LIMIT $1",
+                &format!("SELECT {cols} FROM audit_logs ORDER BY timestamp DESC LIMIT $1"),
             )
             .bind(limit)
             .fetch_all(&self.db)
@@ -178,10 +253,52 @@ impl AuditService {
         Ok(rows)
     }
 
+    /// Verify the integrity of the hash chain from genesis to the latest entry.
+    ///
+    /// Iterates over all entries in order, recomputes each entry's hash from
+    /// its ``previous_hash`` + canonical data, and checks it matches the
+    /// stored ``hash``.  Returns a list of tampered entry IDs (empty = chain
+    /// is intact).
+    pub async fn verify_chain(&self) -> Result<Vec<i64>, AppError> {
+        let rows: Vec<AuditEventRecord> = sqlx::query_as(
+            "SELECT id, event_type, user_id, details, timestamp, hash, previous_hash \
+             FROM audit_logs ORDER BY id ASC",
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        let mut tampered: Vec<i64> = Vec::new();
+        let mut expected_prev = String::new();
+
+        for row in &rows {
+            // Recompute what the hash should be.
+            let canonical = CanonicalAuditData {
+                previous_hash: &expected_prev,
+                event_type: &row.event_type,
+                user_id: row.user_id.as_deref(),
+                details: &row.details,
+                timestamp: &row.timestamp,
+            };
+            let json = serde_json::to_string(&canonical).unwrap_or_default();
+            let mut hasher = Sha256::new();
+            hasher.update(json.as_bytes());
+            let computed = format!("{:x}", hasher.finalize());
+
+            // Verify previous_hash link.
+            if row.previous_hash != expected_prev || row.hash != computed {
+                tampered.push(row.id);
+            }
+
+            expected_prev = row.hash.clone();
+        }
+
+        Ok(tampered)
+    }
+
     /// CQRS Read Path: Fetches single audit record.
     pub async fn get_event(&self, id: i64) -> Result<AuditEventRecord, AppError> {
         let event = sqlx::query_as(
-            "SELECT id, event_type, user_id, details, timestamp FROM audit_logs WHERE id = $1",
+            "SELECT id, event_type, user_id, details, timestamp, hash, previous_hash FROM audit_logs WHERE id = $1",
         )
         .bind(id)
         .fetch_optional(&self.db)

--- a/backend/tests/audit_cqrs_tests.rs
+++ b/backend/tests/audit_cqrs_tests.rs
@@ -1,4 +1,4 @@
-use backend::services::audit::{AuditDomainEvent, AuditEventRequest};
+use backend::services::audit::{AuditDomainEvent, AuditEventRequest, compute_hash};
 use serde_json::json;
 use uuid::Uuid;
 
@@ -13,6 +13,8 @@ fn test_audit_domain_event_serialization() {
         details: json!({"ip": "127.0.0.1"}),
         sequence_number: 1,
         timestamp: chrono::Utc::now(),
+        hash: "abc123".to_string(),
+        previous_hash: "".to_string(),
     };
 
     let serialized = serde_json::to_string(&event).expect("Should serialize domain event");
@@ -20,6 +22,8 @@ fn test_audit_domain_event_serialization() {
 
     assert_eq!(deserialized.event_id, event_id);
     assert_eq!(deserialized.event_type, "USER_LOGIN");
+    assert_eq!(deserialized.hash, "abc123");
+    assert_eq!(deserialized.previous_hash, "");
 }
 
 #[test]
@@ -32,4 +36,107 @@ fn test_audit_event_request_structure() {
     };
 
     assert_eq!(req.event_type, "CONTRACT_DEPLOYED");
+}
+
+#[test]
+fn test_compute_hash_genesis_entry() {
+    let event = AuditDomainEvent {
+        event_id: Uuid::new_v4(),
+        aggregate_id: "genesis".to_string(),
+        event_type: "GENESIS".to_string(),
+        user_id: None,
+        details: json!({"init": true}),
+        sequence_number: 1,
+        timestamp: chrono::Utc::now(),
+        hash: String::new(),
+        previous_hash: String::new(),
+    };
+
+    let hash = compute_hash("", &event);
+    // Genesis hash should be a 64-char hex string (SHA-256).
+    assert_eq!(hash.len(), 64);
+    assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn test_compute_hash_chaining() {
+    let timestamp = chrono::Utc::now();
+
+    let event1 = AuditDomainEvent {
+        event_id: Uuid::new_v4(),
+        aggregate_id: "a1".to_string(),
+        event_type: "ACTION_A".to_string(),
+        user_id: Some("user1".to_string()),
+        details: json!({"step": 1}),
+        sequence_number: 1,
+        timestamp,
+        hash: String::new(),
+        previous_hash: String::new(),
+    };
+
+    let hash1 = compute_hash("", &event1);
+    assert_eq!(hash1.len(), 64);
+
+    let event2 = AuditDomainEvent {
+        event_id: Uuid::new_v4(),
+        aggregate_id: "a2".to_string(),
+        event_type: "ACTION_B".to_string(),
+        user_id: Some("user2".to_string()),
+        details: json!({"step": 2}),
+        sequence_number: 2,
+        timestamp,
+        hash: String::new(),
+        previous_hash: hash1.clone(),
+    };
+
+    let hash2 = compute_hash(&hash1, &event2);
+    assert_eq!(hash2.len(), 64);
+    // hash2 must differ from hash1.
+    assert_ne!(hash2, hash1);
+}
+
+#[test]
+fn test_compute_hash_chain_deterministic() {
+    let timestamp = chrono::Utc::now();
+
+    let event = AuditDomainEvent {
+        event_id: Uuid::new_v4(),
+        aggregate_id: "det".to_string(),
+        event_type: "DETERMINISTIC".to_string(),
+        user_id: None,
+        details: json!({"val": 42}),
+        sequence_number: 1,
+        timestamp,
+        hash: String::new(),
+        previous_hash: "prevhash123".to_string(),
+    };
+
+    let hash_a = compute_hash("prevhash123", &event);
+    let hash_b = compute_hash("prevhash123", &event);
+
+    // Same inputs must produce the same hash.
+    assert_eq!(hash_a, hash_b);
+}
+
+#[test]
+fn test_compute_hash_different_prev_hash_changes_result() {
+    let timestamp = chrono::Utc::now();
+
+    let event = AuditDomainEvent {
+        event_id: Uuid::new_v4(),
+        aggregate_id: "diff".to_string(),
+        event_type: "DIFF".to_string(),
+        user_id: None,
+        details: json!({"x": 1}),
+        sequence_number: 1,
+        timestamp,
+        hash: String::new(),
+        previous_hash: String::new(),
+    };
+
+    let hash1 = compute_hash("aaaa", &event);
+    let hash2 = compute_hash("bbbb", &event);
+
+    // Different previous_hash must yield different chain hash.
+    assert_ne!(hash1, hash2);
 }


### PR DESCRIPTION
Closes #743

## Changes

### `backend/src/services/audit.rs`
- **Added `hash` and `previous_hash` fields** to `AuditDomainEvent`, `AuditProjection`, and `AuditEventRecord` — each entry now stores its own hash and the hash of the preceding entry
- **Added `compute_hash(previous_hash, event) -> String`** — computes `SHA-256(previous_hash || canonical_json)` where canonical JSON includes only semantic fields (`event_type`, `user_id`, `details`, `timestamp`), excluding non-deterministic metadata (`event_id`, `sequence_number`)
- **Added `CanonicalAuditData`** — a serializable struct that defines exactly which fields enter the hash, ensuring cross-replica determinism
- **Updated `log_event()`** — reads the previous hash from Redis (`audit:last_hash`), computes the chain hash, writes the new hash back to Redis, then publishes the event
- **Added `verify_chain() -> Result<Vec<i64>, AppError>`** — iterates all entries in order, recomputes each hash from its `previous_hash`, and returns a list of tampered entry `id`s (empty = chain intact). Detects both unauthorized modification (hash mismatch) and unauthorized insertion/deletion (previous_hash link broken)
- **Updated `project_event()`** — stores `hash` and `previous_hash` alongside existing fields
- **Updated `list_events()` and `get_event()`** — SELECT the new `hash` and `previous_hash` columns

### `backend/migrations/20260528000000_audit_logs.sql`
- Added `hash TEXT NOT NULL DEFAULT ''` and `previous_hash TEXT NOT NULL DEFAULT ''` columns
- Added `idx_audit_logs_id_asc` index for efficient chain-walk queries

### `backend/tests/audit_cqrs_tests.rs`
- Updated existing tests to include `hash` and `previous_hash` fields
- Added 4 new tests:
  - `test_compute_hash_genesis_entry` — genesis hash is valid SHA-256 hex
  - `test_compute_hash_chaining` — two consecutive entries form a chain
  - `test_compute_hash_chain_deterministic` — identical inputs produce identical hashes
  - `test_compute_hash_different_prev_hash_changes_result` — different previous_hash changes chain

## Acceptance Criteria
- [x] Tamper verification function detects unauthorized sequence insertion or modification
- [x] SHA-256 hash chain implemented for audit log entry sequences

## Type of Change
- [x] New feature (security, non-breaking)

ends #743