### PR TITLE
docs(adr): add ADR index, template, and link from ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -680,6 +680,7 @@ Verify:
 
 ## Further Reading
 
+- [Architecture Decision Records](docs/adr/) — Index of all ADRs
 - [Soroban Documentation](https://soroban.stellar.org/)
 - [Cargo Workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)
 - [Proc Macros](https://doc.rust-lang.org/reference/procedural-macros.html)

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,36 @@
+# ADR-0001: Record Architecture Decisions
+
+## Status
+
+Accepted
+
+## Context
+
+The Crucible project needs a lightweight, version-controlled method for capturing important architectural decisions. Without a written record, the rationale behind design choices is lost over time, making onboarding harder and increasing the risk of repeating past mistakes.
+
+## Decision
+
+We will use Architecture Decision Records (ADRs), as described by Michael Nygard (http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+Each ADR is a short Markdown file stored in `docs/adr/` with a filename format of `NNNN-title-with-dashes.md`. Every ADR contains:
+
+- **Title** — A short description of the decision.
+- **Status** — One of: Proposed, Accepted, Deprecated, Superseded.
+- **Context** — The problem or forces that motivated the decision.
+- **Decision** — The chosen approach.
+- **Consequences** — Trade-offs, benefits, and risks.
+- **Alternatives Considered** — Other approaches that were explored.
+
+The index of ADRs is maintained in `docs/adr/README.md`.
+
+## Consequences
+
+- Architectural decisions are permanently recorded and discoverable by all contributors.
+- Proposing a new ADR requires a pull request with the same review process as code changes.
+- ADRs should be updated (or superseded by a new ADR) when the architecture evolves.
+
+## Alternatives Considered
+
+- **Wiki / Confluence** — Not version-controlled; drifts from the codebase.
+- **Code comments** — Too fragmented; no overall picture.
+- **No documentation** — Leads to knowledge loss and inconsistent contributions.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,1 +1,39 @@
 # Architecture Decision Records
+
+This directory contains the Architecture Decision Records (ADRs) for the Crucible project.
+
+ADRs document important architectural decisions, including the context, alternatives considered, and the final decision.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-record-architecture-decisions.md) | Record Architecture Decisions | Accepted |
+
+## Template
+
+To propose a new ADR, create a new file `docs/adr/NNNN-title-with-dashes.md` following the template below:
+
+```markdown
+# ADR-NNNN: Title
+
+## Status
+
+[Proposed \| Accepted \| Deprecated \| Superseded]
+
+## Context
+
+Describe the problem, constraints, and forces at play.
+
+## Decision
+
+Describe the chosen approach and why.
+
+## Consequences
+
+Describe trade-offs, benefits, and risks.
+
+## Alternatives Considered
+
+Briefly list alternatives that were explored and why they were not chosen.
+```


### PR DESCRIPTION
- Expand docs/adr/README.md with a full index and template guidance
- Add ADR-0001 (Record Architecture Decisions) as the first decision record
- Add link to ADR docs in ARCHITECTURE.md Further Reading section

Closes #747