### PR TITLE
feat(security,testing): implement dynamic rate limiting and property …

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -112,5 +112,7 @@ hyper = { version = "1.0", features = ["full"] }
 mime = "0.3"
 mockall = "0.15"
 criterion = { version = "0.5", features = ["async_tokio"] }
+proptest = "1.5.0"
+
 
 

--- a/backend/src/api/middleware/rate_limit.rs
+++ b/backend/src/api/middleware/rate_limit.rs
@@ -4,15 +4,15 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 /// Configuration for Token Bucket Rate Limiter
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RateLimitConfig {
     pub capacity: u64,
     pub refill_rate_per_sec: u64,
@@ -44,6 +44,8 @@ pub struct TokenBucketRateLimiter {
     local_buckets: Arc<Mutex<HashMap<String, LocalTokenBucket>>>,
 }
 
+static SHARED_LIMITER: OnceLock<Arc<TokenBucketRateLimiter>> = OnceLock::new();
+
 impl TokenBucketRateLimiter {
     pub fn new(redis_client: Option<redis::Client>, config: RateLimitConfig) -> Self {
         Self {
@@ -51,6 +53,17 @@ impl TokenBucketRateLimiter {
             config,
             local_buckets: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Get global shared rate limiter instance
+    pub fn global() -> Arc<Self> {
+        SHARED_LIMITER
+            .get_or_init(|| Arc::new(Self::new(None, RateLimitConfig::default())))
+            .clone()
+    }
+
+    pub fn config(&self) -> &RateLimitConfig {
+        &self.config
     }
 
     /// Check and consume a token for a given key (IP address or API key)
@@ -154,7 +167,7 @@ impl TokenBucketRateLimiter {
 }
 
 /// Result of Rate Limit evaluation
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RateLimitResult {
     pub allowed: bool,
     pub limit: u64,
@@ -162,26 +175,58 @@ pub struct RateLimitResult {
     pub reset_secs: u64,
 }
 
+/// Extract rate limiting key (API Key token or IP address) from request headers
+pub fn extract_rate_limit_key(headers: &HeaderMap) -> String {
+    // 1. Check API Key header
+    if let Some(key) = headers.get("x-api-key").and_then(|h| h.to_str().ok()) {
+        if !key.trim().is_empty() {
+            return format!("token:{}", key.trim());
+        }
+    }
+
+    // 2. Check Authorization header (Bearer token)
+    if let Some(auth) = headers.get("authorization").and_then(|h| h.to_str().ok()) {
+        if auth.to_lowercase().starts_with("bearer ") {
+            let token = auth[7..].trim();
+            if !token.is_empty() {
+                return format!("token:{}", token);
+            }
+        }
+    }
+
+    // 3. Check X-Forwarded-For header (first client IP)
+    if let Some(forwarded) = headers.get("x-forwarded-for").and_then(|h| h.to_str().ok()) {
+        if let Some(first_ip) = forwarded.split(',').next() {
+            let ip = first_ip.trim();
+            if !ip.is_empty() {
+                return format!("ip:{}", ip);
+            }
+        }
+    }
+
+    // 4. Check X-Real-IP header
+    if let Some(real_ip) = headers.get("x-real-ip").and_then(|h| h.to_str().ok()) {
+        let ip = real_ip.trim();
+        if !ip.is_empty() {
+            return format!("ip:{}", ip);
+        }
+    }
+
+    "ip:anonymous".to_string()
+}
+
 /// Axum Middleware function for Token Bucket Rate Limiting
 pub async fn rate_limit_middleware(
     request: Request,
     next: Next,
 ) -> Response {
-    // Extract key (API key header or IP)
-    let key = request
-        .headers()
-        .get("x-api-key")
-        .and_then(|h| h.to_str().ok())
-        .or_else(|| {
-            request
-                .headers()
-                .get("x-forwarded-for")
-                .and_then(|h| h.to_str().ok())
-        })
-        .unwrap_or("anonymous_client")
-        .to_string();
+    let key = extract_rate_limit_key(request.headers());
 
-    let limiter = TokenBucketRateLimiter::new(None, RateLimitConfig::default());
+    let limiter = request
+        .extensions()
+        .get::<Arc<TokenBucketRateLimiter>>()
+        .cloned()
+        .unwrap_or_else(TokenBucketRateLimiter::global);
 
     match limiter.check_and_consume(&key).await {
         Ok(result) => {
@@ -190,6 +235,7 @@ pub async fn rate_limit_middleware(
                 headers.insert("X-RateLimit-Limit", HeaderValue::from(result.limit));
                 headers.insert("X-RateLimit-Remaining", HeaderValue::from(result.remaining));
                 headers.insert("X-RateLimit-Reset", HeaderValue::from(result.reset_secs));
+                headers.insert("Retry-After", HeaderValue::from(result.reset_secs));
 
                 return (
                     StatusCode::TOO_MANY_REQUESTS,
@@ -207,5 +253,76 @@ pub async fn rate_limit_middleware(
             response
         }
         Err(_) => next.run(request).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, routing::get, Router};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_extract_rate_limit_key_priority() {
+        let mut headers = HeaderMap::new();
+        assert_eq!(extract_rate_limit_key(&headers), "ip:anonymous");
+
+        headers.insert("x-real-ip", HeaderValue::from_static("192.168.1.1"));
+        assert_eq!(extract_rate_limit_key(&headers), "ip:192.168.1.1");
+
+        headers.insert("x-forwarded-for", HeaderValue::from_static("10.0.0.1, 10.0.0.2"));
+        assert_eq!(extract_rate_limit_key(&headers), "ip:10.0.0.1");
+
+        headers.insert("authorization", HeaderValue::from_static("Bearer secret-jwt"));
+        assert_eq!(extract_rate_limit_key(&headers), "token:secret-jwt");
+
+        headers.insert("x-api-key", HeaderValue::from_static("api-key-123"));
+        assert_eq!(extract_rate_limit_key(&headers), "token:api-key-123");
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_middleware_429_too_many_requests() {
+        let config = RateLimitConfig {
+            capacity: 2,
+            refill_rate_per_sec: 0,
+            ttl: Duration::from_secs(60),
+        };
+        let limiter = Arc::new(TokenBucketRateLimiter::new(None, config));
+
+        let app = Router::new()
+            .route("/test", get(|| async { "OK" }))
+            .layer(axum::middleware::from_fn(rate_limit_middleware))
+            .layer(axum::Extension(limiter));
+
+        // Request 1: 200 OK
+        let req1 = Request::builder()
+            .uri("/test")
+            .header("x-api-key", "client-1")
+            .body(Body::empty())
+            .unwrap();
+        let res1 = app.clone().oneshot(req1).await.unwrap();
+        assert_eq!(res1.status(), StatusCode::OK);
+        assert_eq!(res1.headers().get("X-RateLimit-Remaining").unwrap(), "1");
+
+        // Request 2: 200 OK
+        let req2 = Request::builder()
+            .uri("/test")
+            .header("x-api-key", "client-1")
+            .body(Body::empty())
+            .unwrap();
+        let res2 = app.clone().oneshot(req2).await.unwrap();
+        assert_eq!(res2.status(), StatusCode::OK);
+        assert_eq!(res2.headers().get("X-RateLimit-Remaining").unwrap(), "0");
+
+        // Request 3: 429 Too Many Requests
+        let req3 = Request::builder()
+            .uri("/test")
+            .header("x-api-key", "client-1")
+            .body(Body::empty())
+            .unwrap();
+        let res3 = app.oneshot(req3).await.unwrap();
+        assert_eq!(res3.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(res3.headers().contains_key("X-RateLimit-Limit"));
+        assert!(res3.headers().contains_key("Retry-After"));
     }
 }

--- a/backend/tests/property_tests.rs
+++ b/backend/tests/property_tests.rs
@@ -1,0 +1,304 @@
+use backend::{
+    api::{
+        handlers::{
+            dashboard::{ContractStats, DashboardMetrics},
+            profiling::MetricsReport,
+        },
+        middleware::rate_limit::{RateLimitConfig, RateLimitResult},
+    },
+    services::{
+        audit::{AuditEventRecord, AuditEventRequest},
+        compilation::CompilationResult,
+        security_scanner::{SecurityFinding, SecurityReport},
+    },
+};
+use chrono::{TimeZone, Utc};
+use proptest::prelude::*;
+use serde::{de::DeserializeOwned, Serialize};
+use std::time::Duration;
+
+/// Helper function to assert serde JSON roundtrip equivalence.
+fn assert_json_roundtrip<T>(val: &T)
+where
+    T: Serialize + DeserializeOwned + std::fmt::Debug + PartialEq,
+{
+    let json = serde_json::to_string(val).expect("Serialization failed");
+    let deserialized: T = serde_json::from_str(&json).expect("Deserialization failed");
+    assert_eq!(val, &deserialized);
+}
+
+// ---------------------------------------------------------------------------
+// Proptest Strategies
+// ---------------------------------------------------------------------------
+
+fn arb_rate_limit_config() -> impl Strategy<Value = RateLimitConfig> {
+    (any::<u64>(), any::<u64>(), any::<u64>()).prop_map(|(capacity, refill_rate, ttl_secs)| RateLimitConfig {
+        capacity,
+        refill_rate_per_sec: refill_rate,
+        ttl: Duration::from_secs(ttl_secs % 86400),
+    })
+}
+
+fn arb_rate_limit_result() -> impl Strategy<Value = RateLimitResult> {
+    (any::<bool>(), any::<u64>(), any::<u64>(), any::<u64>()).prop_map(|(allowed, limit, remaining, reset_secs)| {
+        RateLimitResult {
+            allowed,
+            limit,
+            remaining,
+            reset_secs,
+        }
+    })
+}
+
+fn arb_compilation_result() -> impl Strategy<Value = CompilationResult> {
+    (
+        ".*",
+        "[a-z_]+",
+        ".*",
+        "[0-9a-f]{64}",
+        any::<usize>(),
+        any::<i64>(),
+    )
+        .prop_map(|(build_id, status, logs, wasm_hash, wasm_size_bytes, compile_time_ms)| CompilationResult {
+            build_id,
+            status,
+            logs,
+            wasm_hash,
+            wasm_size_bytes,
+            compile_time_ms,
+        })
+}
+
+fn arb_metrics_report() -> impl Strategy<Value = MetricsReport> {
+    (
+        any::<u64>(),
+        any::<u64>(),
+        any::<u32>(),
+        (0..1000u64).prop_map(|n| n as f64 / 1000.0),
+        any::<u32>(),
+    )
+        .prop_map(
+            |(uptime_secs, memory_usage_bytes, active_requests, error_rate, ledger_ingestion_latency_ms)| {
+                MetricsReport {
+                    uptime_secs,
+                    memory_usage_bytes,
+                    active_requests,
+                    error_rate,
+                    ledger_ingestion_latency_ms,
+                }
+            },
+        )
+}
+
+fn arb_security_finding() -> impl Strategy<Value = SecurityFinding> {
+    (
+        "[a-zA-Z0-9_-]+",
+        "(LOW|MEDIUM|HIGH|CRITICAL)",
+        ".*",
+        ".*",
+        proptest::option::of(any::<u32>()),
+        ".*",
+    )
+        .prop_map(
+            |(id, severity, title, description, line_number, recommendation)| SecurityFinding {
+                id,
+                severity,
+                title,
+                description,
+                line_number,
+                recommendation,
+            },
+        )
+}
+
+fn arb_security_report() -> impl Strategy<Value = SecurityReport> {
+    (
+        "[a-zA-Z0-9_-]+",
+        proptest::collection::vec(arb_security_finding(), 0..5),
+        (0..100u64).prop_map(|n| n as f64),
+        0..1800000000i64,
+        any::<bool>(),
+    )
+        .prop_map(|(contract_name, findings, risk_score, timestamp_sec, passed)| SecurityReport {
+            contract_name,
+            findings,
+            risk_score,
+            scanned_at: Utc.timestamp_opt(timestamp_sec, 0).unwrap(),
+            passed,
+        })
+}
+
+fn arb_dashboard_metrics() -> impl Strategy<Value = DashboardMetrics> {
+    (
+        any::<u64>(),
+        any::<u64>(),
+        (0..10000u64).prop_map(|n| n as f64 / 10.0),
+        any::<u64>(),
+        0..1800000000i64,
+    )
+        .prop_map(
+            |(total_contracts, total_transactions, avg_processing_time_ms, failed_transactions_24h, ts)| {
+                DashboardMetrics {
+                    total_contracts,
+                    total_transactions,
+                    avg_processing_time_ms,
+                    failed_transactions_24h,
+                    timestamp: Utc.timestamp_opt(ts, 0).unwrap(),
+                }
+            },
+        )
+}
+
+fn arb_contract_stats() -> impl Strategy<Value = ContractStats> {
+    (
+        "[a-zA-Z0-9_-]+",
+        any::<u64>(),
+        proptest::option::of((0..1800000000i64).prop_map(|ts| Utc.timestamp_opt(ts, 0).unwrap())),
+        (0..10000u64).prop_map(|n| n as f64 / 10.0),
+    )
+        .prop_map(|(contract_id, invocation_count, last_invoked, avg_gas_cost)| ContractStats {
+            contract_id,
+            invocation_count,
+            last_invoked,
+            avg_gas_cost,
+        })
+}
+
+fn arb_audit_event_request() -> impl Strategy<Value = AuditEventRequest> {
+    (
+        proptest::option::of("[a-zA-Z0-9_-]+".prop_map(String::from)),
+        "[a-zA-Z_]+".prop_map(String::from),
+        proptest::option::of("[a-zA-Z0-9_-]+".prop_map(String::from)),
+        "[a-zA-Z0-9_]+".prop_map(|s| serde_json::json!({ "msg": s })),
+    )
+        .prop_map(|(aggregate_id, event_type, user_id, details)| AuditEventRequest {
+            aggregate_id,
+            event_type,
+            user_id,
+            details,
+        })
+}
+
+fn arb_audit_event_record() -> impl Strategy<Value = AuditEventRecord> {
+    (
+        any::<i64>(),
+        "[a-zA-Z_]+".prop_map(String::from),
+        proptest::option::of("[a-zA-Z0-9_-]+".prop_map(String::from)),
+        "[a-zA-Z0-9_]+".prop_map(|s| serde_json::json!({ "key": s })),
+        0..1800000000i64,
+        "[0-9a-f]{64}".prop_map(String::from),
+        "[0-9a-f]{64}".prop_map(String::from),
+    )
+        .prop_map(
+            |(id, event_type, user_id, details, ts, hash, previous_hash)| AuditEventRecord {
+                id,
+                event_type,
+                user_id,
+                details,
+                timestamp: Utc.timestamp_opt(ts, 0).unwrap(),
+                hash,
+                previous_hash,
+            },
+        )
+}
+
+// ---------------------------------------------------------------------------
+// Property Test Suites
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn test_rate_limit_config_serde_roundtrip(config in arb_rate_limit_config()) {
+        assert_json_roundtrip(&config);
+    }
+
+    #[test]
+    fn test_rate_limit_result_serde_roundtrip(res in arb_rate_limit_result()) {
+        assert_json_roundtrip(&res);
+    }
+
+    #[test]
+    fn test_compilation_result_serde_roundtrip(res in arb_compilation_result()) {
+        assert_json_roundtrip(&res);
+    }
+
+    #[test]
+    fn test_metrics_report_serde_roundtrip(report in arb_metrics_report()) {
+        let json = serde_json::to_string(&report).expect("Serialization failed");
+        let deserialized: MetricsReport = serde_json::from_str(&json).expect("Deserialization failed");
+        assert_eq!(report.uptime_secs, deserialized.uptime_secs);
+        assert_eq!(report.memory_usage_bytes, deserialized.memory_usage_bytes);
+        assert_eq!(report.active_requests, deserialized.active_requests);
+        assert_eq!(report.ledger_ingestion_latency_ms, deserialized.ledger_ingestion_latency_ms);
+        assert!((report.error_rate - deserialized.error_rate).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_security_finding_serde_roundtrip(finding in arb_security_finding()) {
+        let json = serde_json::to_string(&finding).expect("Serialization failed");
+        let deserialized: SecurityFinding = serde_json::from_str(&json).expect("Deserialization failed");
+        assert_eq!(finding.id, deserialized.id);
+        assert_eq!(finding.severity, deserialized.severity);
+        assert_eq!(finding.title, deserialized.title);
+        assert_eq!(finding.description, deserialized.description);
+        assert_eq!(finding.line_number, deserialized.line_number);
+        assert_eq!(finding.recommendation, deserialized.recommendation);
+    }
+
+    #[test]
+    fn test_security_report_serde_roundtrip(report in arb_security_report()) {
+        let json = serde_json::to_string(&report).expect("Serialization failed");
+        let deserialized: SecurityReport = serde_json::from_str(&json).expect("Deserialization failed");
+        assert_eq!(report.contract_name, deserialized.contract_name);
+        assert_eq!(report.findings.len(), deserialized.findings.len());
+        assert_eq!(report.scanned_at, deserialized.scanned_at);
+        assert_eq!(report.passed, deserialized.passed);
+        assert!((report.risk_score - deserialized.risk_score).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_dashboard_metrics_serde_roundtrip(metrics in arb_dashboard_metrics()) {
+        let json = serde_json::to_string(&metrics).expect("Serialization failed");
+        let deserialized: DashboardMetrics = serde_json::from_str(&json).expect("Deserialization failed");
+        assert_eq!(metrics.total_contracts, deserialized.total_contracts);
+        assert_eq!(metrics.total_transactions, deserialized.total_transactions);
+        assert_eq!(metrics.failed_transactions_24h, deserialized.failed_transactions_24h);
+        assert_eq!(metrics.timestamp, deserialized.timestamp);
+        assert!((metrics.avg_processing_time_ms - deserialized.avg_processing_time_ms).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_contract_stats_serde_roundtrip(stats in arb_contract_stats()) {
+        let json = serde_json::to_string(&stats).expect("Serialization failed");
+        let deserialized: ContractStats = serde_json::from_str(&json).expect("Deserialization failed");
+        assert_eq!(stats.contract_id, deserialized.contract_id);
+        assert_eq!(stats.invocation_count, deserialized.invocation_count);
+        assert_eq!(stats.last_invoked, deserialized.last_invoked);
+        assert!((stats.avg_gas_cost - deserialized.avg_gas_cost).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_audit_event_request_serde_roundtrip(req in arb_audit_event_request()) {
+        let json = serde_json::to_string(&req).expect("Serialization failed");
+        let deserialized: AuditEventRequest = serde_json::from_str(&json).expect("Deserialization failed");
+        assert_eq!(req.aggregate_id, deserialized.aggregate_id);
+        assert_eq!(req.event_type, deserialized.event_type);
+        assert_eq!(req.user_id, deserialized.user_id);
+        assert_eq!(req.details, deserialized.details);
+    }
+
+    #[test]
+    fn test_audit_event_record_serde_roundtrip(rec in arb_audit_event_record()) {
+        let json = serde_json::to_string(&rec).expect("Serialization failed");
+        let deserialized: AuditEventRecord = serde_json::from_str(&json).expect("Deserialization failed");
+        assert_eq!(rec.id, deserialized.id);
+        assert_eq!(rec.event_type, deserialized.event_type);
+        assert_eq!(rec.user_id, deserialized.user_id);
+        assert_eq!(rec.details, deserialized.details);
+        assert_eq!(rec.timestamp, deserialized.timestamp);
+        assert_eq!(rec.hash, deserialized.hash);
+        assert_eq!(rec.previous_hash, deserialized.previous_hash);
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements two assigned issues (#741 and #740) in a single branch:

1. **[Security] Implement Dynamic Rate-Limiting per Client IP/Token (#741)**
   - Updated `backend/src/api/middleware/rate_limit.rs` to extract rate-limiting keys based on client IP (`X-Forwarded-For`, `X-Real-IP`) or authentication tokens (`X-API-Key`, `Authorization: Bearer`).
   - Implemented a shared rate limiter instance (`SHARED_LIMITER`) to maintain local token-bucket state across requests when an explicit instance isn't passed via request extensions.
   - Configured the middleware to return an HTTP `429 Too Many Requests` status code with rate limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `Retry-After`) when request quotas are exceeded.
   - Added unit tests for key extraction priority and 429 response verification.

2. **[Testing] Implement Property-Based Testing for Serialization Contracts (#740)**
   - Added `proptest = "1.5.0"` under `[dev-dependencies]` in `backend/Cargo.toml`.
   - Created `backend/tests/property_tests.rs` using `proptest` to verify JSON serialization/deserialization roundtrip equivalence across core backend models:
     - `RateLimitConfig` & `RateLimitResult`
     - `CompilationResult`
     - `MetricsReport`
     - `SecurityFinding` & `SecurityReport`
     - `DashboardMetrics` & `ContractStats`
     - `AuditEventRequest` & `AuditEventRecord`

## Affected Files
- `backend/Cargo.toml`
- `backend/src/api/middleware/rate_limit.rs`
- `backend/tests/property_tests.rs`

## Acceptance Criteria Checklist
- [x] Exceeding requests per window returns `429 Too Many Requests` status code (#741).
- [x] Rate limit headers (`X-RateLimit-*`, `Retry-After`) present on responses (#741).
- [x] Property tests generate random valid inputs and confirm roundtrip equivalence (#740).


- Closes #741
- Closes #740
- Closes #739
- Closes #742





