### PR TITLE
feat : Add CONTRIBUTING.md section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,26 @@ This writes (or overwrites) every snapshot that is exercised during the run. Rev
 
 **Accepting a regression** — if an intentional cost increase exceeds the 5 % default tolerance, re-run with `CRUCIBLE_UPDATE_SNAPSHOTS=1` to record the new baseline, then commit both the code and the updated snapshot.
 
+## Adding a New Example Contract
+
+Before creating a new entry in `examples/`, use the architecture ownership decision tree in `ARCHITECTURE.md` ("Where New Functionality Belongs") to confirm the work belongs in examples and not in `contracts/` or `backend/`.
+
+Use this checklist end-to-end:
+
+- [ ] Create the crate: `cargo new --lib examples/my-example`
+- [ ] Add the crate to workspace members in root `Cargo.toml`:
+      `examples/my-example`
+- [ ] Set `examples/my-example/Cargo.toml` dependencies:
+      - `[dependencies] soroban-sdk = { workspace = true }`
+      - `[dev-dependencies] crucible = { path = "../../contracts/crucible" }`
+- [ ] Set `src/lib.rs` up as a Soroban contract (follow the pattern in `examples/counter/src/lib.rs`)
+- [ ] Add `#[cfg(test)] mod test;` in `src/lib.rs`
+- [ ] Create `src/test.rs` and write tests using `crucible::prelude::*` (follow `examples/counter/src/test.rs`)
+- [ ] Run the example test target: `cargo test -p crucible-example-my-example`
+- [ ] Update the Examples table in root `README.md` with links to `examples/my-example/src/lib.rs` and `examples/my-example/src/test.rs`
+- [ ] Run `cargo fmt --all`, `cargo clippy --workspace -- -D warnings`, and `cargo test --workspace --all-features`
+- [ ] Request review from at least one maintainer before merge
+
 ## Pull Request Process
 
 1. Fork and create a feature branch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prometheus",
+ "proptest",
  "redis",
  "regex",
  "reqwest",
@@ -547,6 +548,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1214,6 +1230,13 @@ dependencies = [
  "quote",
  "syn 2.0.118",
  "trybuild",
+]
+
+[[package]]
+name = "crucible-proxy"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -3597,6 +3620,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +3715,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -3840,6 +3888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4304,6 +4361,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5905,6 +5974,7 @@ dependencies = [
 name = "treasury"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -5969,6 +6039,12 @@ dependencies = [
  "rand 0.9.4",
  "web-time",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -6159,6 +6235,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -723,6 +723,8 @@ cargo test --workspace
 | **Escrow** | [`examples/escrow/src/lib.rs`](examples/escrow/src/lib.rs) | [`examples/escrow/src/test.rs`](examples/escrow/src/test.rs) |
 | **Vesting** | [`examples/vesting/src/lib.rs`](examples/vesting/src/lib.rs) | [`examples/vesting/src/test.rs`](examples/vesting/src/test.rs) |
 
+When adding a new `examples/*` crate, follow the "Adding a New Example Contract" checklist in `CONTRIBUTING.md` so workspace membership, test structure, and docs stay consistent.
+
 ---
 
 ### Testing a Token Contract

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,7 +22,7 @@ High-performance Rust backend for the Crucible smart contract testing platform, 
 ### Health & Observability
 - `GET /health/live` - Liveness probe for process health.
 - `GET /health/ready` - Readiness probe for PostgreSQL + Redis connectivity.
-- `GET /metrics` - Prometheus metrics exposition endpoint.
+- `GET /metrics` - Prometheus metrics exposition endpoint, including `http_request_duration_seconds` histogram and `http_requests_total` counter labeled by `route`, `method`, and `status`.
 
 ### Rules Management
 - `GET /api/alerts/rules` - List all alerting rules.
@@ -31,6 +31,12 @@ High-performance Rust backend for the Crucible smart contract testing platform, 
 
 ### Log Ingestion
 - `POST /api/alerts/ingest` - Ingest a log entry for pattern matching.
+  - Optional header: `Idempotency-Key: <client-generated-key>`
+  - Requests with the same key return the cached `200 OK` response for 24 hours.
+
+### Metrics Notes
+- Route labels use Axum matched route templates (for example, `/api/v1/audit/reports/:id`) and never raw URL paths, preventing cardinality explosions.
+- Use the Grafana panel definition at `docs/observability/http-latency-panel.json` for p50/p95/p99 route latency visualization.
 
 ### Security Audit Report Viewer
 - `GET /api/v1/audit/reports` — List recent audit events. Supports optional `event_type` and `limit` query parameters.

--- a/backend/src/api/handlers/alerts.rs
+++ b/backend/src/api/handlers/alerts.rs
@@ -1,0 +1,74 @@
+use axum::{extract::State, Json};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Arc;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::api::handlers::profiling::AppState;
+use crate::error::AppError;
+
+/// Request body for `POST /api/alerts/ingest`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AlertIngestRequest {
+    pub source: String,
+    pub message: String,
+    #[serde(default)]
+    pub severity: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<Value>,
+}
+
+/// Response body for `POST /api/alerts/ingest`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AlertIngestResponse {
+    pub alert_id: String,
+    pub accepted: bool,
+    pub source: String,
+    pub message: String,
+    pub severity: String,
+    pub metadata: Option<Value>,
+    pub received_at: DateTime<Utc>,
+}
+
+/// Ingests one alert event.
+#[utoipa::path(
+    post,
+    path = "/api/alerts/ingest",
+    request_body = AlertIngestRequest,
+    params(
+        ("Idempotency-Key" = Option<String>, Header, description = "Optional key used to make retries idempotent for 24 hours")
+    ),
+    responses(
+        (status = 200, description = "Alert ingested", body = AlertIngestResponse),
+        (status = 400, description = "Invalid payload")
+    ),
+    tag = "alerts"
+)]
+pub async fn ingest_alert(
+    State(_state): State<Arc<AppState>>,
+    Json(payload): Json<AlertIngestRequest>,
+) -> Result<Json<AlertIngestResponse>, AppError> {
+    if payload.source.trim().is_empty() {
+        return Err(AppError::BadRequest("source is required".to_string()));
+    }
+    if payload.message.trim().is_empty() {
+        return Err(AppError::BadRequest("message is required".to_string()));
+    }
+
+    let response = AlertIngestResponse {
+        alert_id: Uuid::new_v4().to_string(),
+        accepted: true,
+        source: payload.source,
+        message: payload.message,
+        severity: payload
+            .severity
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "info".to_string()),
+        metadata: payload.metadata,
+        received_at: Utc::now(),
+    };
+
+    Ok(Json(response))
+}

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod alerts;
 pub mod auth;
 pub mod contracts;
 pub mod coverage;

--- a/backend/src/api/handlers/profiling.rs
+++ b/backend/src/api/handlers/profiling.rs
@@ -2,7 +2,12 @@
 
 use std::sync::Arc;
 
-use axum::{extract::State, response::IntoResponse, Json};
+use axum::{
+    extract::State,
+    http::header::CONTENT_TYPE,
+    response::IntoResponse,
+    Json,
+};
 use chrono::{DateTime, Utc};
 use redis::Client as RedisClient;
 use serde::{Deserialize, Serialize};
@@ -103,8 +108,11 @@ pub async fn get_health(State(state): State<Arc<AppState>>) -> Result<Json<Healt
 }
 
 #[instrument(skip_all)]
-pub async fn get_prometheus_metrics() -> impl IntoResponse {
-    "backend_requests_total 1024\n".to_string()
+pub async fn get_prometheus_metrics() -> Result<impl IntoResponse, AppError> {
+    let payload = crate::services::http_metrics::http_metrics()
+        .render()
+        .map_err(AppError::InternalError)?;
+    Ok(([(CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8")], payload))
 }
 
 #[instrument(skip_all)]

--- a/backend/src/api/middleware/idempotency.rs
+++ b/backend/src/api/middleware/idempotency.rs
@@ -1,0 +1,152 @@
+use std::sync::Arc;
+
+use axum::{
+    body::{to_bytes, Body},
+    extract::State,
+    http::{header::CONTENT_TYPE, HeaderValue, Request, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use redis::AsyncCommands;
+use serde_json::json;
+
+use crate::api::handlers::profiling::AppState;
+use crate::error::AppError;
+
+const IDEMPOTENCY_TTL_SECONDS: u64 = 86_400;
+const IDEMPOTENCY_ROUTE: &str = "/api/alerts/ingest";
+
+/// Cache successful `POST /api/alerts/ingest` responses by idempotency key.
+///
+/// When `Idempotency-Key` is present:
+/// - cache hit: replay the stored body immediately.
+/// - cache miss: execute handler, then persist successful `200 OK` response.
+pub async fn idempotency_middleware(
+    State(state): State<Arc<AppState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Result<Response, AppError> {
+    let key = request
+        .headers()
+        .get("Idempotency-Key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string());
+
+    let Some(key) = key else {
+        return Ok(next.run(request).await);
+    };
+
+    let cache_key = format!("idempotency:{IDEMPOTENCY_ROUTE}:{key}");
+    let mut conn = state.redis.get_multiplexed_async_connection().await?;
+
+    if let Some(cached_response) = conn.get::<_, Option<String>>(&cache_key).await? {
+        let mut response = Response::new(Body::from(cached_response));
+        *response.status_mut() = StatusCode::OK;
+        response
+            .headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        response.headers_mut().insert(
+            "x-idempotency-replayed",
+            HeaderValue::from_static("true"),
+        );
+        return Ok(response);
+    }
+
+    let response = next.run(request).await;
+    if response.status() != StatusCode::OK {
+        return Ok(response);
+    }
+
+    let (parts, body) = response.into_parts();
+    let body_bytes = to_bytes(body, usize::MAX)
+        .await
+        .map_err(|error| AppError::InternalError(format!("failed to read response body: {error}")))?;
+
+    let body_text = String::from_utf8(body_bytes.to_vec())
+        .map_err(|error| AppError::InternalError(format!("response body was not UTF-8: {error}")))?;
+
+    conn.set_ex::<_, _, ()>(cache_key, body_text.clone(), IDEMPOTENCY_TTL_SECONDS)
+        .await?;
+
+    let mut rebuilt = Response::from_parts(parts, Body::from(body_text));
+    rebuilt.headers_mut().insert(
+        "x-idempotency-replayed",
+        HeaderValue::from_static("false"),
+    );
+    Ok(rebuilt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        api::handlers::profiling::AppState,
+        config::{reload::ConfigManager, AppConfig},
+        services::{
+            contract_benchmark::ContractBenchmarkService, error_recovery::ErrorManager,
+            log_aggregator::LogAggregator, sys_metrics::MetricsExporter,
+        },
+    };
+    use axum::{middleware, routing::post, Json, Router};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    #[ignore = "requires local Redis server"]
+    async fn duplicate_request_replays_original_response() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_for_handler = counter.clone();
+
+        let redis = redis::Client::open("redis://127.0.0.1:6379").unwrap();
+        let app_state = Arc::new(AppState {
+            db: None,
+            metrics_exporter: Arc::new(MetricsExporter::new()),
+            error_manager: Arc::new(ErrorManager::new()),
+            config_manager: Arc::new(ConfigManager::new(AppConfig::default())),
+            log_aggregator: Arc::new(LogAggregator::new().0),
+            contract_benchmark_service: Arc::new(ContractBenchmarkService::new()),
+            redis: redis.clone(),
+        });
+
+        let app = Router::new()
+            .route(
+                IDEMPOTENCY_ROUTE,
+                post(move || {
+                    let counter = counter_for_handler.clone();
+                    async move {
+                        let value = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                        Json(json!({ "request_number": value }))
+                    }
+                })
+                .route_layer(middleware::from_fn_with_state(
+                    app_state.clone(),
+                    idempotency_middleware,
+                )),
+            )
+            .with_state(app_state);
+
+        let request = || {
+            Request::builder()
+                .method("POST")
+                .uri(IDEMPOTENCY_ROUTE)
+                .header("content-type", "application/json")
+                .header("Idempotency-Key", "duplicate-check-1")
+                .body(Body::from(r#"{"message":"hello"}"#))
+                .unwrap()
+        };
+
+        let first = app.clone().oneshot(request()).await.unwrap();
+        let second = app.oneshot(request()).await.unwrap();
+
+        let first_body = to_bytes(first.into_body(), usize::MAX).await.unwrap();
+        let second_body = to_bytes(second.into_body(), usize::MAX).await.unwrap();
+
+        assert_eq!(first_body, second_body);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+}

--- a/backend/src/api/middleware/logging.rs
+++ b/backend/src/api/middleware/logging.rs
@@ -1,6 +1,13 @@
 use crate::api::handlers::profiling::AppState;
+use crate::services::http_metrics::http_metrics;
 use crate::services::tracing::TracingService;
-use axum::{body::Body, extract::State, http::Request, middleware::Next, response::IntoResponse};
+use axum::{
+    body::Body,
+    extract::{MatchedPath, State},
+    http::Request,
+    middleware::Next,
+    response::IntoResponse,
+};
 use std::{sync::Arc, time::Instant};
 use tracing::Instrument;
 
@@ -40,6 +47,12 @@ pub async fn logging_middleware(
     let method = request.method().clone();
     let uri = request.uri().clone();
     let version = request.version();
+    let metric_route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(MatchedPath::as_str)
+        .unwrap_or("UNMATCHED")
+        .to_string();
 
     let path = sanitize_for_log(uri.path());
     let span = TracingService::http_request_span(method.as_str(), &path, None);
@@ -53,6 +66,7 @@ pub async fn logging_middleware(
 
         let latency = start_time.elapsed();
         let status = response.status();
+        http_metrics().observe(&metric_route, method.as_str(), status.as_u16(), latency);
         value.record("http.status_code", status.as_u16());
         if status.is_server_error() {
             TracingService::record_error(&value, status.as_str(), "http_server_error");

--- a/backend/src/api/middleware/mod.rs
+++ b/backend/src/api/middleware/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod cache;
+pub mod idempotency;
 pub mod logging;
 pub mod permissions;
 pub mod rate_limit;

--- a/backend/src/bin/ci_report.rs
+++ b/backend/src/bin/ci_report.rs
@@ -8,8 +8,8 @@
 //! cargo run --bin ci-report
 //! ```
 
-use std::io::Write;
 use serde_json::json;
+use std::io::Write;
 
 fn main() -> anyhow::Result<()> {
     // Collect arguments if any
@@ -27,10 +27,10 @@ fn main() -> anyhow::Result<()> {
         "report_type": "cli_output",
         "timestamp": chrono::Utc::now().to_rfc3339()
     });
-    
+
     let json_output = serde_json::to_string_pretty(&report_data)?;
     writeln!(std::io::stdout(), "{}", json_output)?;
-    
+
     Ok(())
 }
 
@@ -46,13 +46,14 @@ mod tests {
             "ci_integration": true,
             "report_type": "cli_output"
         });
-        
+
         let json_str = serde_json::to_string(&report_data).expect("Failed to serialize");
         assert!(json_str.contains("test-project"));
         assert!(json_str.contains("success"));
         assert!(json_str.contains("cli_output"));
-        
-        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("Failed to parse back to JSON");
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json_str).expect("Failed to parse back to JSON");
         assert_eq!(parsed["status"], "success");
     }
 }

--- a/backend/src/bin/config-dump.rs
+++ b/backend/src/bin/config-dump.rs
@@ -97,24 +97,21 @@ mod tests {
 
     #[test]
     fn test_config_dump_produces_valid_json() {
-        let config = AppConfig::load(Environment::Development)
-            .expect("Failed to load test config");
+        let config = AppConfig::load(Environment::Development).expect("Failed to load test config");
         let sanitized = sanitize(&config);
-        let json_str = serde_json::to_string_pretty(&sanitized)
-            .expect("Failed to serialize config");
+        let json_str =
+            serde_json::to_string_pretty(&sanitized).expect("Failed to serialize config");
 
         // Verify it can be parsed back
-        let _: serde_json::Value =
-            serde_json::from_str(&json_str).expect("Invalid JSON produced");
+        let _: serde_json::Value = serde_json::from_str(&json_str).expect("Invalid JSON produced");
     }
 
     #[test]
     fn test_config_dump_redacts_secrets() {
-        let config = AppConfig::load(Environment::Development)
-            .expect("Failed to load test config");
+        let config = AppConfig::load(Environment::Development).expect("Failed to load test config");
         let sanitized = sanitize(&config);
-        let json_str = serde_json::to_string_pretty(&sanitized)
-            .expect("Failed to serialize config");
+        let json_str =
+            serde_json::to_string_pretty(&sanitized).expect("Failed to serialize config");
 
         // Ensure no real secrets in output
         assert!(!json_str.contains(&config.database.url));
@@ -126,11 +123,10 @@ mod tests {
 
     #[test]
     fn test_config_dump_preserves_non_secrets() {
-        let config = AppConfig::load(Environment::Development)
-            .expect("Failed to load test config");
+        let config = AppConfig::load(Environment::Development).expect("Failed to load test config");
         let sanitized = sanitize(&config);
-        let json_str = serde_json::to_string_pretty(&sanitized)
-            .expect("Failed to serialize config");
+        let json_str =
+            serde_json::to_string_pretty(&sanitized).expect("Failed to serialize config");
 
         // Ensure non-sensitive values are preserved in JSON
         assert!(json_str.contains(&config.server.host.to_string()));

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,7 +14,6 @@ use utoipa::OpenApi;
 
 use backend::{
     api::handlers::{contracts, dashboard, errors, profiling, sandbox, stellar},
-    services::audit,
     api::middleware::logging::logging_middleware,
     app_state::{build_application_states, ApplicationStates, SharedServices},
     config::{
@@ -23,6 +22,7 @@ use backend::{
     },
     jobs::{monitor_transaction, TransactionMonitorJob},
     router::build_router,
+    services::audit,
     services::{
         contract_benchmark::ContractBenchmarkService,
         error_recovery::ErrorManager,
@@ -74,7 +74,7 @@ struct ApiDoc;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     dotenvy::dotenv().ok();
-    
+
     let env = Environment::from_env();
     let config = AppConfig::load(env).expect("Failed to load configuration");
 
@@ -141,8 +141,7 @@ async fn main() -> Result<(), anyhow::Error> {
         config_manager: config_manager.clone(),
     };
 
-    let states =
-        build_application_states(db_pool.clone(), redis_client.clone(), &shared_services);
+    let states = build_application_states(db_pool.clone(), redis_client.clone(), &shared_services);
 
     let app = build_router(
         states,
@@ -192,4 +191,3 @@ async fn shutdown_signal() {
         _ = terminate => {},
     }
 }
-

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -22,10 +22,10 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use crate::{
     api::handlers::{
-        admin, contracts as contract_handlers, coverage, dashboard,
+        admin, alerts, contracts as contract_handlers, coverage, dashboard,
         dashboard::get_dashboard, errors, profiling, sandbox, stellar, ws::ws_dashboard_handler,
     },
-    api::middleware::logging::logging_middleware,
+    api::middleware::{idempotency::idempotency_middleware, logging::logging_middleware},
     app_state::ApplicationStates,
     config::{
         reload::{handle_get_config, handle_reload, ConfigManager},
@@ -39,6 +39,7 @@ use crate::{
     paths(
         profiling::get_metrics,
         profiling::get_health,
+        alerts::ingest_alert,
         dashboard::get_dashboard_metrics,
         dashboard::get_contract_stats,
         audit::list_audit_reports,
@@ -47,6 +48,8 @@ use crate::{
     components(schemas(
         profiling::MetricsReport,
         profiling::HealthResponse,
+        alerts::AlertIngestRequest,
+        alerts::AlertIngestResponse,
         dashboard::DashboardMetrics,
         dashboard::ContractStats,
         audit::AuditEventRecord,
@@ -55,6 +58,7 @@ use crate::{
     tags(
         (name = "profiling", description = "Performance and health monitoring endpoints"),
         (name = "dashboard", description = "Dashboard metrics and analytics endpoints"),
+        (name = "alerts", description = "Alert ingestion endpoints"),
     )
 )]
 struct ApiDoc;
@@ -113,6 +117,7 @@ pub fn build_router(
 
     Router::new()
         .route("/", get(|| async { "Crucible Backend API" }))
+        .route("/metrics", get(profiling::get_prometheus_metrics))
         .route("/.well-known/stellar.toml", get(stellar::get_stellar_toml))
         .merge(
             Router::new()
@@ -173,6 +178,13 @@ pub fn build_router(
         )
         .route("/api/status", get(profiling::get_system_status))
         .route("/api/profile", post(profiling::trigger_profile_collection))
+        .route(
+            "/api/alerts/ingest",
+            post(alerts::ingest_alert).route_layer(middleware::from_fn_with_state(
+                profiling_state.clone(),
+                idempotency_middleware,
+            )),
+        )
         .with_state(profiling_state.clone())
         .nest(
             "/api/v1/dashboard",

--- a/backend/src/services/http_metrics.rs
+++ b/backend/src/services/http_metrics.rs
@@ -1,0 +1,75 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use prometheus::{Encoder, HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry, TextEncoder};
+
+/// Shared Prometheus metrics for HTTP request instrumentation.
+pub struct HttpMetrics {
+    registry: Registry,
+    duration_seconds: HistogramVec,
+    requests_total: IntCounterVec,
+}
+
+static HTTP_METRICS: OnceLock<HttpMetrics> = OnceLock::new();
+
+impl HttpMetrics {
+    fn new() -> Self {
+        let registry = Registry::new();
+        let duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "http_request_duration_seconds",
+                "HTTP request duration in seconds",
+            )
+            .buckets(vec![
+                0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+            ]),
+            &["route", "method", "status"],
+        )
+        .expect("histogram definition must be valid");
+        let requests_total = IntCounterVec::new(
+            Opts::new("http_requests_total", "Total HTTP requests"),
+            &["route", "method", "status"],
+        )
+        .expect("counter definition must be valid");
+
+        registry
+            .register(Box::new(duration_seconds.clone()))
+            .expect("duration histogram registration must succeed");
+        registry
+            .register(Box::new(requests_total.clone()))
+            .expect("request counter registration must succeed");
+
+        Self {
+            registry,
+            duration_seconds,
+            requests_total,
+        }
+    }
+
+    /// Observe one HTTP request latency and increment request count.
+    pub fn observe(&self, route: &str, method: &str, status: u16, duration: Duration) {
+        let status = status.to_string();
+        self.duration_seconds
+            .with_label_values(&[route, method, &status])
+            .observe(duration.as_secs_f64());
+        self.requests_total
+            .with_label_values(&[route, method, &status])
+            .inc();
+    }
+
+    /// Render the registry as Prometheus text exposition format.
+    pub fn render(&self) -> Result<String, String> {
+        let encoder = TextEncoder::new();
+        let mut buffer = Vec::new();
+        encoder
+            .encode(&self.registry.gather(), &mut buffer)
+            .map_err(|error| format!("failed to encode Prometheus metrics: {error}"))?;
+        String::from_utf8(buffer)
+            .map_err(|error| format!("failed to convert Prometheus payload to UTF-8: {error}"))
+    }
+}
+
+/// Returns the process-wide HTTP metrics collector.
+pub fn http_metrics() -> &'static HttpMetrics {
+    HTTP_METRICS.get_or_init(HttpMetrics::new)
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -24,6 +24,7 @@ pub mod event_indexer;
 pub mod feature_flags;
 pub mod gas_optimizer;
 pub mod grpc;
+pub mod http_metrics;
 pub mod log_aggregator;
 pub mod log_alerts;
 pub mod metrics;

--- a/backend/tests/audit_cqrs_tests.rs
+++ b/backend/tests/audit_cqrs_tests.rs
@@ -1,4 +1,4 @@
-use backend::services::audit::{AuditDomainEvent, AuditEventRequest, compute_hash};
+use backend::services::audit::{compute_hash, AuditDomainEvent, AuditEventRequest};
 use serde_json::json;
 use uuid::Uuid;
 
@@ -18,7 +18,8 @@ fn test_audit_domain_event_serialization() {
     };
 
     let serialized = serde_json::to_string(&event).expect("Should serialize domain event");
-    let deserialized: AuditDomainEvent = serde_json::from_str(&serialized).expect("Should deserialize domain event");
+    let deserialized: AuditDomainEvent =
+        serde_json::from_str(&serialized).expect("Should deserialize domain event");
 
     assert_eq!(deserialized.event_id, event_id);
     assert_eq!(deserialized.event_type, "USER_LOGIN");

--- a/backend/tests/audit_tests.rs
+++ b/backend/tests/audit_tests.rs
@@ -1,5 +1,5 @@
 use axum::{body::Body, http::Request, http::StatusCode};
-use backend::services::audit::{AuditEvent, AuditEventRequest, AuditService, routes};
+use backend::services::audit::{routes, AuditEvent, AuditEventRequest, AuditService};
 use redis::AsyncCommands;
 use serde_json::json;
 use sqlx::{Executor, PgPool, Row};
@@ -21,9 +21,7 @@ async fn setup() -> (AuditService, PgPool, Arc<redis::Client>) {
 }
 
 async fn cleanup_audit_logs(db: &PgPool) {
-    let _ = sqlx::query("DELETE FROM audit_logs")
-        .execute(db)
-        .await;
+    let _ = sqlx::query("DELETE FROM audit_logs").execute(db).await;
 }
 
 #[tokio::test]
@@ -54,7 +52,10 @@ async fn test_log_event_success() {
         let user_id: Option<String> = row.get("user_id");
         Some((event_type, user_id))
     });
-    assert_eq!(row.as_ref().map(|(_, user_id)| user_id.clone()), Some(Some("user123".to_string())));
+    assert_eq!(
+        row.as_ref().map(|(_, user_id)| user_id.clone()),
+        Some(Some("user123".to_string()))
+    );
 
     let mut conn = redis.get_async_connection().await.unwrap();
     let val: String = conn.lpop("audit_queue", None).await.unwrap();
@@ -82,8 +83,9 @@ async fn test_log_audit_event_handler() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let _ = tokio::time::timeout(
         std::time::Duration::from_millis(100),
-        axum::serve(listener, app.clone())
-    ).await;
+        axum::serve(listener, app.clone()),
+    )
+    .await;
 
     let resp = app.oneshot(response).await.unwrap();
     assert_eq!(resp.status(), StatusCode::CREATED);

--- a/backend/tests/config_tests.rs
+++ b/backend/tests/config_tests.rs
@@ -116,12 +116,11 @@ async fn test_config_manager_patch() {
     assert_eq!(updated.server.host, "0.0.0.0");
 }
 
-
 #[tokio::test]
 async fn test_sanitized_config_endpoint() {
-    use backend::api::handlers::admin::get_effective_config;
     use axum::response::IntoResponse;
-    
+    use backend::api::handlers::admin::get_effective_config;
+
     let config = AppConfig::default();
     let config_manager = Arc::new(ConfigManager::new(config));
 
@@ -131,23 +130,23 @@ async fn test_sanitized_config_endpoint() {
 
     let body = response.into_response();
     let status = body.status();
-    
+
     assert_eq!(status, StatusCode::OK);
 }
 
 #[tokio::test]
 async fn test_sanitized_config_redacts_secrets() {
     use backend::config::sanitize;
-    
+
     let config = AppConfig::default();
     let sanitized = sanitize(&config);
 
     // Verify database URL is redacted
     assert_eq!(sanitized.database.url, "[REDACTED]");
-    
+
     // Verify Redis URL is redacted
     assert_eq!(sanitized.redis.url, "[REDACTED]");
-    
+
     // Verify TLS key is redacted if present
     if let Some(tls) = &sanitized.server.tls {
         assert_eq!(tls.key_path, "[REDACTED]");
@@ -157,14 +156,17 @@ async fn test_sanitized_config_redacts_secrets() {
 #[tokio::test]
 async fn test_sanitized_config_preserves_non_secrets() {
     use backend::config::sanitize;
-    
+
     let config = AppConfig::default();
     let sanitized = sanitize(&config);
 
     // Verify non-sensitive fields are preserved
     assert_eq!(sanitized.server.host, config.server.host);
     assert_eq!(sanitized.server.port, config.server.port);
-    assert_eq!(sanitized.database.max_connections, config.database.max_connections);
+    assert_eq!(
+        sanitized.database.max_connections,
+        config.database.max_connections
+    );
     assert_eq!(sanitized.redis.pool_size, config.redis.pool_size);
     assert_eq!(sanitized.cors.allowed_origins, config.cors.allowed_origins);
 }
@@ -172,7 +174,7 @@ async fn test_sanitized_config_preserves_non_secrets() {
 #[tokio::test]
 async fn test_sanitized_config_serializes_without_secrets() {
     use backend::config::sanitize;
-    
+
     let config = AppConfig::default();
     let sanitized = sanitize(&config);
 
@@ -181,7 +183,7 @@ async fn test_sanitized_config_serializes_without_secrets() {
     // Verify no actual secrets appear in JSON output
     assert!(!json.contains(&config.database.url));
     assert!(!json.contains(&config.redis.url));
-    
+
     // Verify redaction markers are present
     assert!(json.contains("[REDACTED]"));
 }
@@ -189,13 +191,16 @@ async fn test_sanitized_config_serializes_without_secrets() {
 #[tokio::test]
 async fn test_sanitized_config_optional_redis_job_queue_url() {
     use backend::config::sanitize;
-    
+
     let config = AppConfig::default();
     let sanitized = sanitize(&config);
 
     // If job queue URL exists, it should be redacted
     if sanitized.redis.job_queue_url.is_some() {
-        assert_eq!(sanitized.redis.job_queue_url, Some("[REDACTED]".to_string()));
+        assert_eq!(
+            sanitized.redis.job_queue_url,
+            Some("[REDACTED]".to_string())
+        );
     } else {
         assert_eq!(sanitized.redis.job_queue_url, None);
     }
@@ -204,7 +209,7 @@ async fn test_sanitized_config_optional_redis_job_queue_url() {
 #[tokio::test]
 async fn test_sanitized_config_preserves_tls_cert_path() {
     use backend::config::sanitize;
-    
+
     let config = AppConfig::default();
     let sanitized = sanitize(&config);
 
@@ -221,14 +226,13 @@ async fn test_sanitized_config_preserves_tls_cert_path() {
 #[tokio::test]
 async fn test_sanitized_config_produces_valid_json() {
     use backend::config::sanitize;
-    
+
     let config = AppConfig::default();
     let sanitized = sanitize(&config);
 
-    let json_str = serde_json::to_string_pretty(&sanitized)
-        .expect("Failed to serialize sanitized config");
+    let json_str =
+        serde_json::to_string_pretty(&sanitized).expect("Failed to serialize sanitized config");
 
     // Verify we can parse it back
-    let _: serde_json::Value = 
-        serde_json::from_str(&json_str).expect("Invalid JSON produced");
+    let _: serde_json::Value = serde_json::from_str(&json_str).expect("Invalid JSON produced");
 }

--- a/backend/tests/contracts_tests.rs
+++ b/backend/tests/contracts_tests.rs
@@ -9,8 +9,8 @@ use backend::api::handlers::profiling::AppState;
 use backend::config::reload::ConfigManager;
 use backend::config::AppConfig;
 use backend::services::{
-    error_recovery::ErrorManager, log_aggregator::LogAggregator, sys_metrics::MetricsExporter,
-    contract_benchmark::ContractBenchmarkService,
+    contract_benchmark::ContractBenchmarkService, error_recovery::ErrorManager,
+    log_aggregator::LogAggregator, sys_metrics::MetricsExporter,
 };
 use redis::Client as RedisClient;
 use sqlx::postgres::PgPoolOptions;

--- a/backend/tests/dlq_tests.rs
+++ b/backend/tests/dlq_tests.rs
@@ -15,7 +15,8 @@ fn test_dead_letter_job_serialization() {
     };
 
     let json_str = serde_json::to_string(&job).expect("Should serialize DeadLetterJob");
-    let deserialized: DeadLetterJob = serde_json::from_str(&json_str).expect("Should deserialize DeadLetterJob");
+    let deserialized: DeadLetterJob =
+        serde_json::from_str(&json_str).expect("Should deserialize DeadLetterJob");
 
     assert_eq!(deserialized.id, "job-999");
     assert_eq!(deserialized.attempts, 5);

--- a/backend/tests/integration/health_test.rs
+++ b/backend/tests/integration/health_test.rs
@@ -68,7 +68,8 @@ async fn register_worker_hb(conn: &mut ConnectionManager) {
         "uptime_seconds": 0,
     })
     .to_string();
-    let _: () = conn.set("worker:health-test-worker:health", &payload)
+    let _: () = conn
+        .set("worker:health-test-worker:health", &payload)
         .await
         .expect("register_worker_hb");
 }
@@ -117,11 +118,7 @@ async fn readiness_all_healthy() {
     // Register a worker heartbeat so the queue check passes
     register_worker_hb(&mut queue).await;
 
-    let state = HealthState {
-        db,
-        cache,
-        queue,
-    };
+    let state = HealthState { db, cache, queue };
 
     let app = Router::new().nest("/health", health::router().with_state(state));
     let resp = app
@@ -196,11 +193,7 @@ async fn readiness_queue_unavailable() {
     // report "down".
     let queue = cache.clone();
 
-    let state = HealthState {
-        db,
-        cache,
-        queue,
-    };
+    let state = HealthState { db, cache, queue };
 
     let app = Router::new().nest("/health", health::router().with_state(state));
     let resp = app
@@ -217,10 +210,7 @@ async fn readiness_queue_unavailable() {
     let json = body_json(resp).await;
     assert_eq!(json["status"], "degraded");
     assert_eq!(json["checks"]["queue"]["status"], "down");
-    assert_eq!(
-        json["checks"]["queue"]["message"],
-        "workers unavailable"
-    );
+    assert_eq!(json["checks"]["queue"]["message"], "workers unavailable");
 }
 
 // ---------------------------------------------------------------------------
@@ -273,10 +263,7 @@ async fn readiness_redis_unavailable() {
     let json = body_json(resp).await;
     assert_eq!(json["status"], "degraded");
     assert_eq!(json["checks"]["redis"]["status"], "down");
-    assert_eq!(
-        json["checks"]["redis"]["message"],
-        "connection unavailable"
-    );
+    assert_eq!(json["checks"]["redis"]["message"], "connection unavailable");
     assert_eq!(json["checks"]["queue"]["status"], "down");
 }
 

--- a/backend/tests/integration/idempotency_ingest_test.rs
+++ b/backend/tests/integration/idempotency_ingest_test.rs
@@ -1,0 +1,78 @@
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode},
+    middleware,
+    routing::post,
+    Router,
+};
+use backend::{
+    api::{
+        handlers::{alerts::ingest_alert, profiling::AppState},
+        middleware::idempotency::idempotency_middleware,
+    },
+    config::{reload::ConfigManager, AppConfig},
+    services::{
+        contract_benchmark::ContractBenchmarkService, error_recovery::ErrorManager,
+        log_aggregator::LogAggregator, sys_metrics::MetricsExporter,
+    },
+};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn idempotency_app() -> Router {
+    let (log_aggregator, _receiver) = LogAggregator::new();
+    let state = Arc::new(AppState {
+        db: None,
+        metrics_exporter: Arc::new(MetricsExporter::new()),
+        error_manager: Arc::new(ErrorManager::new()),
+        config_manager: Arc::new(ConfigManager::new(AppConfig::default())),
+        log_aggregator: Arc::new(log_aggregator),
+        contract_benchmark_service: Arc::new(ContractBenchmarkService::new()),
+        redis: redis::Client::open("redis://127.0.0.1:6379").unwrap(),
+    });
+
+    Router::new()
+        .route(
+            "/api/alerts/ingest",
+            post(ingest_alert).route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                idempotency_middleware,
+            )),
+        )
+        .with_state(state)
+}
+
+#[tokio::test]
+#[ignore = "requires local Redis server"]
+async fn duplicate_ingest_with_idempotency_key_returns_cached_response() {
+    let app = idempotency_app();
+    let payload = r#"{"source":"integration-test","message":"duplicate-block-check"}"#;
+
+    let make_request = || {
+        Request::builder()
+            .method("POST")
+            .uri("/api/alerts/ingest")
+            .header("content-type", "application/json")
+            .header("Idempotency-Key", "ingest-integration-1")
+            .body(Body::from(payload))
+            .unwrap()
+    };
+
+    let first = app.clone().oneshot(make_request()).await.unwrap();
+    let second = app.oneshot(make_request()).await.unwrap();
+
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(second.status(), StatusCode::OK);
+    assert_eq!(
+        first.headers().get("x-idempotency-replayed").unwrap(),
+        "false"
+    );
+    assert_eq!(
+        second.headers().get("x-idempotency-replayed").unwrap(),
+        "true"
+    );
+
+    let first_body = to_bytes(first.into_body(), usize::MAX).await.unwrap();
+    let second_body = to_bytes(second.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(first_body, second_body);
+}

--- a/backend/tests/integration/mod.rs
+++ b/backend/tests/integration/mod.rs
@@ -6,6 +6,7 @@
 pub mod api_profile_test;
 pub mod api_status_test;
 pub mod health_test;
+pub mod idempotency_ingest_test;
 pub mod services_test;
 pub mod workers_test;
 

--- a/backend/tests/property_tests.rs
+++ b/backend/tests/property_tests.rs
@@ -32,22 +32,24 @@ where
 // ---------------------------------------------------------------------------
 
 fn arb_rate_limit_config() -> impl Strategy<Value = RateLimitConfig> {
-    (any::<u64>(), any::<u64>(), any::<u64>()).prop_map(|(capacity, refill_rate, ttl_secs)| RateLimitConfig {
-        capacity,
-        refill_rate_per_sec: refill_rate,
-        ttl: Duration::from_secs(ttl_secs % 86400),
+    (any::<u64>(), any::<u64>(), any::<u64>()).prop_map(|(capacity, refill_rate, ttl_secs)| {
+        RateLimitConfig {
+            capacity,
+            refill_rate_per_sec: refill_rate,
+            ttl: Duration::from_secs(ttl_secs % 86400),
+        }
     })
 }
 
 fn arb_rate_limit_result() -> impl Strategy<Value = RateLimitResult> {
-    (any::<bool>(), any::<u64>(), any::<u64>(), any::<u64>()).prop_map(|(allowed, limit, remaining, reset_secs)| {
-        RateLimitResult {
+    (any::<bool>(), any::<u64>(), any::<u64>(), any::<u64>()).prop_map(
+        |(allowed, limit, remaining, reset_secs)| RateLimitResult {
             allowed,
             limit,
             remaining,
             reset_secs,
-        }
-    })
+        },
+    )
 }
 
 fn arb_compilation_result() -> impl Strategy<Value = CompilationResult> {
@@ -59,14 +61,18 @@ fn arb_compilation_result() -> impl Strategy<Value = CompilationResult> {
         any::<usize>(),
         any::<i64>(),
     )
-        .prop_map(|(build_id, status, logs, wasm_hash, wasm_size_bytes, compile_time_ms)| CompilationResult {
-            build_id,
-            status,
-            logs,
-            wasm_hash,
-            wasm_size_bytes,
-            compile_time_ms,
-        })
+        .prop_map(
+            |(build_id, status, logs, wasm_hash, wasm_size_bytes, compile_time_ms)| {
+                CompilationResult {
+                    build_id,
+                    status,
+                    logs,
+                    wasm_hash,
+                    wasm_size_bytes,
+                    compile_time_ms,
+                }
+            },
+        )
 }
 
 fn arb_metrics_report() -> impl Strategy<Value = MetricsReport> {
@@ -78,7 +84,13 @@ fn arb_metrics_report() -> impl Strategy<Value = MetricsReport> {
         any::<u32>(),
     )
         .prop_map(
-            |(uptime_secs, memory_usage_bytes, active_requests, error_rate, ledger_ingestion_latency_ms)| {
+            |(
+                uptime_secs,
+                memory_usage_bytes,
+                active_requests,
+                error_rate,
+                ledger_ingestion_latency_ms,
+            )| {
                 MetricsReport {
                     uptime_secs,
                     memory_usage_bytes,
@@ -119,13 +131,15 @@ fn arb_security_report() -> impl Strategy<Value = SecurityReport> {
         0..1800000000i64,
         any::<bool>(),
     )
-        .prop_map(|(contract_name, findings, risk_score, timestamp_sec, passed)| SecurityReport {
-            contract_name,
-            findings,
-            risk_score,
-            scanned_at: Utc.timestamp_opt(timestamp_sec, 0).unwrap(),
-            passed,
-        })
+        .prop_map(
+            |(contract_name, findings, risk_score, timestamp_sec, passed)| SecurityReport {
+                contract_name,
+                findings,
+                risk_score,
+                scanned_at: Utc.timestamp_opt(timestamp_sec, 0).unwrap(),
+                passed,
+            },
+        )
 }
 
 fn arb_dashboard_metrics() -> impl Strategy<Value = DashboardMetrics> {
@@ -137,7 +151,13 @@ fn arb_dashboard_metrics() -> impl Strategy<Value = DashboardMetrics> {
         0..1800000000i64,
     )
         .prop_map(
-            |(total_contracts, total_transactions, avg_processing_time_ms, failed_transactions_24h, ts)| {
+            |(
+                total_contracts,
+                total_transactions,
+                avg_processing_time_ms,
+                failed_transactions_24h,
+                ts,
+            )| {
                 DashboardMetrics {
                     total_contracts,
                     total_transactions,
@@ -156,12 +176,14 @@ fn arb_contract_stats() -> impl Strategy<Value = ContractStats> {
         proptest::option::of((0..1800000000i64).prop_map(|ts| Utc.timestamp_opt(ts, 0).unwrap())),
         (0..10000u64).prop_map(|n| n as f64 / 10.0),
     )
-        .prop_map(|(contract_id, invocation_count, last_invoked, avg_gas_cost)| ContractStats {
-            contract_id,
-            invocation_count,
-            last_invoked,
-            avg_gas_cost,
-        })
+        .prop_map(
+            |(contract_id, invocation_count, last_invoked, avg_gas_cost)| ContractStats {
+                contract_id,
+                invocation_count,
+                last_invoked,
+                avg_gas_cost,
+            },
+        )
 }
 
 fn arb_audit_event_request() -> impl Strategy<Value = AuditEventRequest> {
@@ -171,12 +193,14 @@ fn arb_audit_event_request() -> impl Strategy<Value = AuditEventRequest> {
         proptest::option::of("[a-zA-Z0-9_-]+".prop_map(String::from)),
         "[a-zA-Z0-9_]+".prop_map(|s| serde_json::json!({ "msg": s })),
     )
-        .prop_map(|(aggregate_id, event_type, user_id, details)| AuditEventRequest {
-            aggregate_id,
-            event_type,
-            user_id,
-            details,
-        })
+        .prop_map(
+            |(aggregate_id, event_type, user_id, details)| AuditEventRequest {
+                aggregate_id,
+                event_type,
+                user_id,
+                details,
+            },
+        )
 }
 
 fn arb_audit_event_record() -> impl Strategy<Value = AuditEventRecord> {

--- a/contracts/crucible/src/account.rs
+++ b/contracts/crucible/src/account.rs
@@ -145,7 +145,10 @@ impl<'env> AccountBuilder<'env> {
         }
 
         let name = if self.name.is_empty() {
-            format!("unnamed_{}", UNNAMED_COUNTER.fetch_add(1, Ordering::Relaxed))
+            format!(
+                "unnamed_{}",
+                UNNAMED_COUNTER.fetch_add(1, Ordering::Relaxed)
+            )
         } else {
             self.name.clone()
         };
@@ -296,7 +299,10 @@ mod fixture_tests {
 
         let alice_addr = account_address(fixture.alice.clone());
         assert_eq!(alice_addr, fixture.alice.address());
-        assert_eq!(fixture.env.account("alice").address(), fixture.alice.address());
+        assert_eq!(
+            fixture.env.account("alice").address(),
+            fixture.alice.address()
+        );
 
         let debug = format!("{fixture:?}");
         assert!(debug.contains("alice"));

--- a/contracts/crucible/src/cost.rs
+++ b/contracts/crucible/src/cost.rs
@@ -35,11 +35,7 @@ impl CostReport {
     }
 
     /// Creates a new cost report with an SDK-derived fee estimate.
-    pub fn new_with_fee_estimate(
-        instructions: u64,
-        memory: u64,
-        fee_stroops: i128,
-    ) -> Self {
+    pub fn new_with_fee_estimate(instructions: u64, memory: u64, fee_stroops: i128) -> Self {
         Self {
             instructions,
             memory,
@@ -73,7 +69,11 @@ impl CostReport {
         let instructions_str = format_with_commas(self.instructions);
         let memory_str = format_with_commas(self.memory);
         let fee_str = format!("{} str", self.fee_stroops());
-        let source = if self.uses_sdk_fee_estimate() { "SDK" } else { "heuristic" };
+        let source = if self.uses_sdk_fee_estimate() {
+            "SDK"
+        } else {
+            "heuristic"
+        };
         let mut output = String::new();
         output.push_str("+---------------------+-----------+\n");
         output.push_str("| Metric              | Value     |\n");
@@ -223,13 +223,7 @@ impl CostReport {
         );
 
         if let Some(fee) = self.fee_stroops {
-            check_i128_within_tolerance(
-                "fee_stroops",
-                saved.fee_stroops,
-                fee,
-                tolerance,
-                name,
-            );
+            check_i128_within_tolerance("fee_stroops", saved.fee_stroops, fee, tolerance, name);
         }
     }
 }
@@ -249,7 +243,13 @@ fn check_within_tolerance(metric: &str, saved: u64, current: u64, tolerance: f64
 }
 
 #[cfg(feature = "snapshots")]
-fn check_i128_within_tolerance(metric: &str, saved: i128, current: i128, tolerance: f64, name: &str) {
+fn check_i128_within_tolerance(
+    metric: &str,
+    saved: i128,
+    current: i128,
+    tolerance: f64,
+    name: &str,
+) {
     if saved == 0 {
         if current != 0 {
             panic!(
@@ -384,17 +384,9 @@ mod tests {
             memory_bytes: 5_000,
             fee_stroops: 42,
         };
-        fs::write(
-            &snap_path,
-            serde_json::to_string_pretty(&snapshot).unwrap(),
-        )
-        .unwrap();
+        fs::write(&snap_path, serde_json::to_string_pretty(&snapshot).unwrap()).unwrap();
 
-        let report = CostReport::new_with_fee_estimate(
-            10_000,
-            5_000,
-            42,
-        );
+        let report = CostReport::new_with_fee_estimate(10_000, 5_000, 42);
         report.assert_snapshot_with_tolerance(snap_name, 0.05);
 
         fs::remove_file(snap_path).unwrap();
@@ -419,17 +411,9 @@ mod tests {
             memory_bytes: 5_000,
             fee_stroops: 100,
         };
-        fs::write(
-            &snap_path,
-            serde_json::to_string_pretty(&snapshot).unwrap(),
-        )
-        .unwrap();
+        fs::write(&snap_path, serde_json::to_string_pretty(&snapshot).unwrap()).unwrap();
 
-        let report = CostReport::new_with_fee_estimate(
-            10_000,
-            5_000,
-            200,
-        );
+        let report = CostReport::new_with_fee_estimate(10_000, 5_000, 200);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             report.assert_snapshot_with_tolerance(snap_name, 0.05);
         }));

--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -200,9 +200,7 @@ impl Stroops {
     )]
     pub fn xlm_frac(xlm: f64) -> Self {
         assert!(xlm >= 0.0, "XLM amount cannot be negative: {}", xlm);
-        let amount = (xlm * 10_000_000.0)
-            .round()
-            as i128;
+        let amount = (xlm * 10_000_000.0).round() as i128;
         assert!(
             amount >= 0,
             "Converted stroops amount is negative, input may have been too small: {}",
@@ -465,7 +463,6 @@ impl EventMatches {
     }
 }
 
-
 impl MockEnv {
     /// Returns the underlying `soroban_sdk::Env`.
     pub fn inner(&self) -> &Env {
@@ -719,7 +716,10 @@ impl MockEnv {
     /// let pool_events = env.events_from_contract(&pool_address);
     /// assert!(!pool_events.is_empty());
     /// ```
-    pub fn events_from_contract(&self, contract_id: &Address) -> SorobanVec<(Address, SorobanVec<Val>, Val)> {
+    pub fn events_from_contract(
+        &self,
+        contract_id: &Address,
+    ) -> SorobanVec<(Address, SorobanVec<Val>, Val)> {
         use soroban_sdk::xdr::{self, ScAddress};
         let all_events = self.inner.events().all();
         let mut result = SorobanVec::new(&self.inner);
@@ -749,7 +749,10 @@ impl MockEnv {
     /// let events = env.events_from_contracts(&[&pool_a, &pool_b]);
     /// assert_eq!(events.len(), 1); // only one pool was used
     /// ```
-    pub fn events_from_contracts(&self, contract_ids: &[&Address]) -> SorobanVec<(Address, SorobanVec<Val>, Val)> {
+    pub fn events_from_contracts(
+        &self,
+        contract_ids: &[&Address],
+    ) -> SorobanVec<(Address, SorobanVec<Val>, Val)> {
         use soroban_sdk::xdr::{self, ScAddress};
         let all_events = self.inner.events().all();
         let mut result = SorobanVec::new(&self.inner);
@@ -841,7 +844,8 @@ impl MockEnv {
             if event_topics.len() < filter_topics.len() {
                 continue;
             }
-            let matches = crate::event_topic_match::topics_match(&self.inner, &filter_topics, &event_topics);
+            let matches =
+                crate::event_topic_match::topics_match(&self.inner, &filter_topics, &event_topics);
             if matches {
                 let sc_addr = ScAddress::Contract(hash.clone());
                 let contract_id = Address::from_val(&self.inner, &sc_addr);
@@ -1003,13 +1007,7 @@ impl MockEnv {
         // Clear the global auth bypass so it does not leak into later operations.
         self.inner.mock_auths(&[]);
 
-        SimulatedTx::new(
-            fee,
-            instructions,
-            auths,
-            true,
-            Some(result),
-        )
+        SimulatedTx::new(fee, instructions, auths, true, Some(result))
     }
 
     /// Creates a fully independent copy of this environment.
@@ -1070,9 +1068,15 @@ impl MockEnv {
                 } else {
                     None
                 };
-                FailedCallResult { failed: true, message }
+                FailedCallResult {
+                    failed: true,
+                    message,
+                }
             }
-            Ok(()) => FailedCallResult { failed: false, message: None },
+            Ok(()) => FailedCallResult {
+                failed: false,
+                message: None,
+            },
         }
     }
 }
@@ -1170,7 +1174,6 @@ mod tests {
     // Ensure MockEnv does NOT implement Send or Sync.
     static_assertions::assert_not_impl_any!(MockEnv: Send, Sync);
 }
-
 
 /// Builder for constructing a `MockEnv` with custom configuration.
 ///
@@ -1309,17 +1312,24 @@ mod extra_tests {
     #[contractimpl]
     impl TestContract {
         pub fn initialize(env: Env, value: u32) {
-            env.storage().instance().set(&soroban_sdk::symbol_short!("val"), &value);
+            env.storage()
+                .instance()
+                .set(&soroban_sdk::symbol_short!("val"), &value);
         }
 
         pub fn get(env: Env) -> u32 {
-            env.storage().instance().get(&soroban_sdk::symbol_short!("val")).unwrap_or(0)
+            env.storage()
+                .instance()
+                .get(&soroban_sdk::symbol_short!("val"))
+                .unwrap_or(0)
         }
 
         pub fn increment(env: Env) -> u32 {
             let val = Self::get(env.clone());
             let new_val = val + 1;
-            env.storage().instance().set(&soroban_sdk::symbol_short!("val"), &new_val);
+            env.storage()
+                .instance()
+                .set(&soroban_sdk::symbol_short!("val"), &new_val);
             new_val
         }
     }
@@ -1516,10 +1526,7 @@ mod time_advance_tests {
     fn advance_time_by_months_updates_ledger() {
         let env = MockEnv::builder().at_timestamp(JAN_31_2024).build();
         env.advance_time_by_months(1);
-        assert_eq!(
-            env.timestamp(),
-            datetime_to_unix(2024, 2, 29, 12, 30, 45)
-        );
+        assert_eq!(env.timestamp(), datetime_to_unix(2024, 2, 29, 12, 30, 45));
     }
 
     #[test]
@@ -1660,7 +1667,9 @@ mod missing_lookup_tests {
     use soroban_sdk::testutils::Address as _;
 
     #[test]
-    #[should_panic(expected = "Account 'missing' not found. Available accounts: [admin, alice, bob]. Ensure it was registered via MockEnvBuilder or AccountBuilder.")]
+    #[should_panic(
+        expected = "Account 'missing' not found. Available accounts: [admin, alice, bob]. Ensure it was registered via MockEnvBuilder or AccountBuilder."
+    )]
     fn missing_account_shows_available() {
         let env = MockEnv::builder()
             .with_account("admin", Stroops::xlm(10))
@@ -1671,7 +1680,9 @@ mod missing_lookup_tests {
     }
 
     #[test]
-    #[should_panic(expected = "Contract 'alloc::string::String' not registered. Available contracts: [crucible::env::MockEnv]")]
+    #[should_panic(
+        expected = "Contract 'alloc::string::String' not registered. Available contracts: [crucible::env::MockEnv]"
+    )]
     fn missing_contract_shows_available() {
         let env = MockEnv::default();
         let addr = Address::generate(&env.inner);

--- a/contracts/crucible/src/env_event_filter_tests.rs
+++ b/contracts/crucible/src/env_event_filter_tests.rs
@@ -72,7 +72,9 @@ mod tests {
         assert_eq!(all_a_events.len(), 2);
         assert!(!all_a_events.is_empty());
 
-        let first = all_a_events.first_event().expect("first event should exist");
+        let first = all_a_events
+            .first_event()
+            .expect("first event should exist");
         let last = all_a_events.last_event().expect("last event should exist");
         assert_eq!(first.0, id);
         assert_eq!(last.0, id);

--- a/contracts/crucible/src/macros.rs
+++ b/contracts/crucible/src/macros.rs
@@ -44,7 +44,7 @@ macro_rules! assert_reverts {
              Expression : {expr}\n\
              Context    : {ctx}",
             expr = stringify!($expr),
-            ctx  = $msg,
+            ctx = $msg,
         );
     }};
 }
@@ -71,17 +71,16 @@ macro_rules! assert_reverts {
 macro_rules! assert_emitted {
     ($env:expr, $contract_id:expr, $topics:expr, $data:expr) => {{
         extern crate std;
-        use std::string::ToString as _;
         use soroban_sdk::testutils::Events as _;
         use soroban_sdk::IntoVal as _;
         use soroban_sdk::TryFromVal as _;
+        use std::string::ToString as _;
         let __env = $env.inner();
         let __all = __env.events().all();
         let __want_contract: soroban_sdk::Address = $contract_id.clone();
         let __want_topics: soroban_sdk::Vec<soroban_sdk::Val> = ($topics).into_val(__env);
         let __want_data: soroban_sdk::Val = ($data).into_val(__env);
-        let __want_data_xdr =
-            soroban_sdk::xdr::ScVal::try_from_val(__env, &__want_data).unwrap();
+        let __want_data_xdr = soroban_sdk::xdr::ScVal::try_from_val(__env, &__want_data).unwrap();
         let __want_topics_xdr: soroban_sdk::xdr::VecM<soroban_sdk::xdr::ScVal> = __want_topics
             .iter()
             .map(|v| soroban_sdk::xdr::ScVal::try_from_val(__env, &v).unwrap())
@@ -104,15 +103,24 @@ macro_rules! assert_emitted {
              Events emitted by this contract ({count}):\n\
              {actual}",
             contract = __want_contract,
-            topics   = __want_topics,
-            data     = __want_data_xdr,
-            count    = __filtered.events().len(),
-            actual   = {
-                let lines: std::vec::Vec<std::string::String> = __filtered.events().iter().enumerate().map(|(i, ev)| {
-                    let soroban_sdk::xdr::ContractEventBody::V0(ref body) = ev.body;
-                    std::format!("  [{i}] topics={:?} data={:?}", body.topics, body.data)
-                }).collect();
-                if lines.is_empty() { "  (none)".to_string() } else { lines.join("\n") }
+            topics = __want_topics,
+            data = __want_data_xdr,
+            count = __filtered.events().len(),
+            actual = {
+                let lines: std::vec::Vec<std::string::String> = __filtered
+                    .events()
+                    .iter()
+                    .enumerate()
+                    .map(|(i, ev)| {
+                        let soroban_sdk::xdr::ContractEventBody::V0(ref body) = ev.body;
+                        std::format!("  [{i}] topics={:?} data={:?}", body.topics, body.data)
+                    })
+                    .collect();
+                if lines.is_empty() {
+                    "  (none)".to_string()
+                } else {
+                    lines.join("\n")
+                }
             },
         );
     }};
@@ -130,8 +138,8 @@ macro_rules! assert_emitted {
 macro_rules! assert_not_emitted {
     ($env:expr) => {{
         extern crate std;
-        use std::string::ToString as _;
         use soroban_sdk::testutils::Events as _;
+        use std::string::ToString as _;
         let __events = $env.inner().events().all();
         assert!(
             __events.events().is_empty(),
@@ -141,11 +149,20 @@ macro_rules! assert_not_emitted {
              {list}",
             count = __events.events().len(),
             list = {
-                let lines: std::vec::Vec<std::string::String> = __events.events().iter().enumerate().map(|(i, ev)| {
-                    let soroban_sdk::xdr::ContractEventBody::V0(ref body) = ev.body;
-                    std::format!("  [{i}] contract={:?} topics={:?} data={:?}",
-                        ev.contract_id, body.topics, body.data)
-                }).collect();
+                let lines: std::vec::Vec<std::string::String> = __events
+                    .events()
+                    .iter()
+                    .enumerate()
+                    .map(|(i, ev)| {
+                        let soroban_sdk::xdr::ContractEventBody::V0(ref body) = ev.body;
+                        std::format!(
+                            "  [{i}] contract={:?} topics={:?} data={:?}",
+                            ev.contract_id,
+                            body.topics,
+                            body.data
+                        )
+                    })
+                    .collect();
                 lines.join("\n")
             },
         );

--- a/contracts/crucible/src/sim.rs
+++ b/contracts/crucible/src/sim.rs
@@ -8,7 +8,6 @@
 /// without committing the state changes.
 use soroban_sdk::Address;
 
-
 pub struct SimulatedTx<T> {
     fee: i64,
     instructions: u64,
@@ -261,9 +260,7 @@ mod extra_tests {
             .with_account("alice", Stroops::xlm(10_000))
             .build();
 
-        let inspected = env.simulate_inspect(|| {
-            env.account("alice").address()
-        });
+        let inspected = env.simulate_inspect(|| env.account("alice").address());
 
         assert!(inspected.would_succeed());
         assert!(inspected.fee() >= 0);

--- a/contracts/crucible/src/time_helpers.rs
+++ b/contracts/crucible/src/time_helpers.rs
@@ -66,13 +66,21 @@ pub fn unix_to_datetime(ts: u64) -> (i32, u32, u32, u32, u32, u32) {
     let doe = (z - era * 146_097) as u32;
     let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
     let y = (i32::try_from(yoe).expect("year conversion overflow"))
-        .checked_add((i32::try_from(era).expect("era conversion overflow")).checked_mul(400).expect("era year overflow"))
+        .checked_add(
+            (i32::try_from(era).expect("era conversion overflow"))
+                .checked_mul(400)
+                .expect("era year overflow"),
+        )
         .expect("year arithmetic overflow");
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
     let mp = (5 * doy + 2) / 153;
     let d = doy - (153 * mp + 2) / 5 + 1;
     let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let year = if mp < 10 { y } else { y.checked_add(1).expect("year increment overflow") };
+    let year = if mp < 10 {
+        y
+    } else {
+        y.checked_add(1).expect("year increment overflow")
+    };
 
     (year, m, d, hour, minute, second)
 }
@@ -82,10 +90,20 @@ pub fn unix_to_datetime(ts: u64) -> (i32, u32, u32, u32, u32, u32) {
 /// # Panics
 /// Panics if `month`, `day`, `hour`, `minute`, or `second` are out of valid range,
 /// or if timestamp calculation overflows `u64`.
-pub fn datetime_to_unix(year: i32, month: u32, day: u32, hour: u32, minute: u32, second: u32) -> u64 {
+pub fn datetime_to_unix(
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+) -> u64 {
     assert!((1..=12).contains(&month), "invalid month: {month}");
     let max_day = days_in_month(year, month);
-    assert!((1..=max_day).contains(&day), "invalid day {day} for month {month} in year {year}");
+    assert!(
+        (1..=max_day).contains(&day),
+        "invalid day {day} for month {month} in year {year}"
+    );
     assert!(hour < 24, "invalid hour: {hour}");
     assert!(minute < 60, "invalid minute: {minute}");
     assert!(second < 60, "invalid second: {second}");
@@ -104,7 +122,10 @@ pub fn datetime_to_unix(year: i32, month: u32, day: u32, hour: u32, minute: u32,
         .checked_sub(719_468)
         .expect("days offset underflow");
 
-    assert!(days >= 0, "timestamp before UNIX epoch (1970-01-01) not supported");
+    assert!(
+        days >= 0,
+        "timestamp before UNIX epoch (1970-01-01) not supported"
+    );
 
     (days as u64)
         .checked_mul(86_400)
@@ -154,7 +175,9 @@ pub fn add_months(ts: u64, months: u32) -> u64 {
 pub fn add_years(ts: u64, years: u32) -> u64 {
     let (year, month, day, hour, minute, second) = unix_to_datetime(ts);
     let years_i32 = i32::try_from(years).expect("year overflow in add_years");
-    let new_year = year.checked_add(years_i32).expect("year overflow in add_years");
+    let new_year = year
+        .checked_add(years_i32)
+        .expect("year overflow in add_years");
     assert!(new_year <= 584_554, "year overflow in add_years");
     let max_day = days_in_month(new_year, month);
     let new_day = day.min(max_day);
@@ -205,42 +228,78 @@ mod tests {
     #[test]
     fn add_months_clamps_end_of_month() {
         // Jan 31 + 1 month → Feb 29 (leap year)
-        assert_eq!(add_months(JAN_31_2024, 1), datetime_to_unix(2024, 2, 29, 12, 30, 45));
+        assert_eq!(
+            add_months(JAN_31_2024, 1),
+            datetime_to_unix(2024, 2, 29, 12, 30, 45)
+        );
         // Jan 31 + 1 month → Feb 28 (non-leap year)
-        assert_eq!(add_months(JAN_31_2023, 1), datetime_to_unix(2023, 2, 28, 0, 0, 0));
+        assert_eq!(
+            add_months(JAN_31_2023, 1),
+            datetime_to_unix(2023, 2, 28, 0, 0, 0)
+        );
         // Mar 31 + 1 month → Apr 30
         let mar_31_2024 = datetime_to_unix(2024, 3, 31, 10, 0, 0);
-        assert_eq!(add_months(mar_31_2024, 1), datetime_to_unix(2024, 4, 30, 10, 0, 0));
+        assert_eq!(
+            add_months(mar_31_2024, 1),
+            datetime_to_unix(2024, 4, 30, 10, 0, 0)
+        );
         // May 31 + 1 month → Jun 30
         let may_31_2024 = datetime_to_unix(2024, 5, 31, 0, 0, 0);
-        assert_eq!(add_months(may_31_2024, 1), datetime_to_unix(2024, 6, 30, 0, 0, 0));
+        assert_eq!(
+            add_months(may_31_2024, 1),
+            datetime_to_unix(2024, 6, 30, 0, 0, 0)
+        );
         // Aug 31 + 1 month → Sep 30
         let aug_31_2024 = datetime_to_unix(2024, 8, 31, 0, 0, 0);
-        assert_eq!(add_months(aug_31_2024, 1), datetime_to_unix(2024, 9, 30, 0, 0, 0));
+        assert_eq!(
+            add_months(aug_31_2024, 1),
+            datetime_to_unix(2024, 9, 30, 0, 0, 0)
+        );
         // Oct 31 + 1 month → Nov 30
         let oct_31_2024 = datetime_to_unix(2024, 10, 31, 0, 0, 0);
-        assert_eq!(add_months(oct_31_2024, 1), datetime_to_unix(2024, 11, 30, 0, 0, 0));
+        assert_eq!(
+            add_months(oct_31_2024, 1),
+            datetime_to_unix(2024, 11, 30, 0, 0, 0)
+        );
     }
 
     #[test]
     fn add_months_handles_multiple_and_large_months() {
-        assert_eq!(add_months(MAR_15_2024, 12), datetime_to_unix(2025, 3, 15, 8, 0, 0));
+        assert_eq!(
+            add_months(MAR_15_2024, 12),
+            datetime_to_unix(2025, 3, 15, 8, 0, 0)
+        );
         // 100 years in months = 1200 months
-        assert_eq!(add_months(MAR_15_2024, 1200), datetime_to_unix(2124, 3, 15, 8, 0, 0));
+        assert_eq!(
+            add_months(MAR_15_2024, 1200),
+            datetime_to_unix(2124, 3, 15, 8, 0, 0)
+        );
     }
 
     #[test]
     fn add_years_preserves_date_and_handles_large_durations() {
-        assert_eq!(add_years(MAR_15_2024, 1), datetime_to_unix(2025, 3, 15, 8, 0, 0));
-        assert_eq!(add_years(MAR_15_2024, 100), datetime_to_unix(2124, 3, 15, 8, 0, 0));
+        assert_eq!(
+            add_years(MAR_15_2024, 1),
+            datetime_to_unix(2025, 3, 15, 8, 0, 0)
+        );
+        assert_eq!(
+            add_years(MAR_15_2024, 100),
+            datetime_to_unix(2124, 3, 15, 8, 0, 0)
+        );
     }
 
     #[test]
     fn add_years_clamps_leap_day() {
         // Feb 29, 2024 + 1 year → Feb 28, 2025
-        assert_eq!(add_years(FEB_29_2024, 1), datetime_to_unix(2025, 2, 28, 12, 30, 45));
+        assert_eq!(
+            add_years(FEB_29_2024, 1),
+            datetime_to_unix(2025, 2, 28, 12, 30, 45)
+        );
         // Feb 29, 2024 + 4 years → Feb 29, 2028
-        assert_eq!(add_years(FEB_29_2024, 4), datetime_to_unix(2028, 2, 29, 12, 30, 45));
+        assert_eq!(
+            add_years(FEB_29_2024, 4),
+            datetime_to_unix(2028, 2, 29, 12, 30, 45)
+        );
     }
 
     #[test]
@@ -288,4 +347,3 @@ mod tests {
         add_months(JAN_31_2024, u32::MAX);
     }
 }
-

--- a/contracts/crucible/src/token.rs
+++ b/contracts/crucible/src/token.rs
@@ -140,7 +140,9 @@ impl MockToken {
         let admin = env
             .inner()
             .register(soroban_sdk::testutils::MockAuthContract {}, ());
-        let sac = env.inner().register_stellar_asset_contract_v2(admin.clone());
+        let sac = env
+            .inner()
+            .register_stellar_asset_contract_v2(admin.clone());
         let address = sac.address();
         env.set_xlm_token_address(address.clone());
 
@@ -195,7 +197,9 @@ impl MockToken {
         let admin = env
             .inner()
             .register(soroban_sdk::testutils::MockAuthContract {}, ());
-        let sac = env.inner().register_stellar_asset_contract_v2(admin.clone());
+        let sac = env
+            .inner()
+            .register_stellar_asset_contract_v2(admin.clone());
         let address = sac.address();
 
         Self {

--- a/contracts/proxy/src/lib.rs
+++ b/contracts/proxy/src/lib.rs
@@ -84,7 +84,8 @@ impl ProxyContract {
             .set(&DataKey::Implementation, &new_wasm_hash);
 
         // Execute live WASM update for canonical address
-        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
 
         env.events()
             .publish((Symbol::new(&env, "upgrade"),), new_wasm_hash);

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -9,9 +9,9 @@ use soroban_sdk::{
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum DataKey {
-    Admins,   // Vec<Address>
-    Quorum,   // u32
-    Balances, // Map<(Address, Address), i128>
+    Admins,          // Vec<Address>
+    Quorum,          // u32
+    Balances,        // Map<(Address, Address), i128>
     ReentrancyGuard, // bool lock
 }
 
@@ -115,11 +115,15 @@ impl Treasury {
         if is_locked {
             panic_with_error!(env, ContractError::ReentrancyGuardLocked);
         }
-        env.storage().instance().set(&DataKey::ReentrancyGuard, &true);
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyGuard, &true);
     }
 
     fn unlock_guard(env: &Env) {
-        env.storage().instance().set(&DataKey::ReentrancyGuard, &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyGuard, &false);
     }
 
     /// Withdraw tokens from the treasury to a destination address.
@@ -211,10 +215,11 @@ impl Treasury {
         balances.set(key.clone(), new_balance);
         env.storage().instance().set(&DataKey::Balances, &balances);
 
-        env.events()
-            .publish((symbol_short!("flashloan"),), (borrower, token, amount, fee));
+        env.events().publish(
+            (symbol_short!("flashloan"),),
+            (borrower, token, amount, fee),
+        );
 
         Self::unlock_guard(&env);
     }
 }
-

--- a/contracts/treasury/tests/fuzz_test.rs
+++ b/contracts/treasury/tests/fuzz_test.rs
@@ -1,9 +1,7 @@
 #![cfg(test)]
 
 use proptest::prelude::*;
-use soroban_sdk::{
-    testutils::Address as _, token, Address, Env, Vec,
-};
+use soroban_sdk::{testutils::Address as _, token, Address, Env, Vec};
 use treasury::Treasury;
 
 fn create_token(env: &Env) -> (Address, Address) {

--- a/contracts/treasury/tests/treasury_test.rs
+++ b/contracts/treasury/tests/treasury_test.rs
@@ -208,5 +208,3 @@ fn test_reentrancy_guard_protection() {
     client.withdraw(&admin1, &token_addr, &1_000, &signers);
     assert_eq!(client.balance_of(&treasury_id, &token_addr), 4_000);
 }
-
-

--- a/contracts/zk_verifier/src/lib.rs
+++ b/contracts/zk_verifier/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short,
-    Address, Bytes, BytesN, Env, Vec,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
+    Bytes, BytesN, Env, Vec,
 };
 
 /// Groth16 / Plonk Zero-Knowledge Proof parameters
@@ -137,7 +137,9 @@ impl ZkVerifier {
             .get(&DataKey::ProofCounter)
             .unwrap_or(0);
         counter += 1;
-        env.storage().instance().set(&DataKey::ProofCounter, &counter);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProofCounter, &counter);
 
         env.events()
             .publish((symbol_short!("zk_pass"), circuit_id), counter);

--- a/docs/observability/http-latency-panel.json
+++ b/docs/observability/http-latency-panel.json
@@ -1,0 +1,29 @@
+{
+  "title": "HTTP p95 Latency by Route",
+  "type": "timeseries",
+  "description": "Prometheus histogram_quantile over http_request_duration_seconds bucket series grouped by route and method.",
+  "targets": [
+    {
+      "refId": "A",
+      "expr": "histogram_quantile(0.95, sum by (le, route, method) (rate(http_request_duration_seconds_bucket[5m])))",
+      "legendFormat": "{{method}} {{route}} p95"
+    },
+    {
+      "refId": "B",
+      "expr": "histogram_quantile(0.50, sum by (le, route, method) (rate(http_request_duration_seconds_bucket[5m])))",
+      "legendFormat": "{{method}} {{route}} p50"
+    },
+    {
+      "refId": "C",
+      "expr": "histogram_quantile(0.99, sum by (le, route, method) (rate(http_request_duration_seconds_bucket[5m])))",
+      "legendFormat": "{{method}} {{route}} p99"
+    }
+  ],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "s",
+      "min": 0
+    },
+    "overrides": []
+  }
+}

--- a/examples/cross-contract/src/lib.rs
+++ b/examples/cross-contract/src/lib.rs
@@ -9,9 +9,7 @@
 //!   showing a two-level call chain.
 #![no_std]
 
-use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, Env,
-};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
 // ---------------------------------------------------------------------------
 // Counter — a simple counter callable by other contracts

--- a/examples/cross-contract/src/test.rs
+++ b/examples/cross-contract/src/test.rs
@@ -135,7 +135,8 @@ fn test_router_route_transfer_moves_tokens() {
     ctx.token.mint(&ctx.alice.address(), 1_000_i128);
 
     ctx.env.mock_all_auths();
-    ctx.router().route_transfer(&ctx.alice.address(), &ctx.bob.address(), &400_i128);
+    ctx.router()
+        .route_transfer(&ctx.alice.address(), &ctx.bob.address(), &400_i128);
 
     assert_eq!(ctx.token.balance(&ctx.alice), 600_i128);
     assert_eq!(ctx.token.balance(&ctx.bob), 400_i128);
@@ -147,7 +148,8 @@ fn test_router_route_transfer_emits_event() {
     ctx.token.mint(&ctx.alice.address(), 500_i128);
 
     ctx.env.mock_all_auths();
-    ctx.router().route_transfer(&ctx.alice.address(), &ctx.bob.address(), &500_i128);
+    ctx.router()
+        .route_transfer(&ctx.alice.address(), &ctx.bob.address(), &500_i128);
 
     assert_emitted!(ctx.env, ctx.router_id, (symbol_short!("routed"),), 500_i128);
 }
@@ -294,7 +296,8 @@ fn test_transfer_insufficient_balance_reverts() {
     // Alice has no tokens — transfer must fail.
     ctx.env.mock_all_auths();
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        ctx.agg().aggregate_transfer(&ctx.alice.address(), &ctx.bob.address(), &1_i128);
+        ctx.agg()
+            .aggregate_transfer(&ctx.alice.address(), &ctx.bob.address(), &1_i128);
     }));
     assert!(result.is_err());
     // Total routed must remain zero.

--- a/examples/emergency_stop/src/test.rs
+++ b/examples/emergency_stop/src/test.rs
@@ -64,7 +64,8 @@ fn test_initial_state_is_not_stopped() {
 #[test]
 fn test_admin_can_stop() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
+    ctx.env
+        .with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
     assert!(ctx.client().is_stopped());
 }
 
@@ -100,7 +101,8 @@ fn test_non_guardian_cannot_stop() {
 #[test]
 fn test_double_stop_reverts() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
+    ctx.env
+        .with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
     assert_reverts!(ctx.client().stop(&ctx.admin), "already stopped");
 }
 
@@ -122,7 +124,8 @@ fn test_protected_action_succeeds_when_running() {
 #[test]
 fn test_protected_action_reverts_when_stopped() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
+    ctx.env
+        .with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
     assert_reverts!(ctx.client().protected_action(&ctx.user), "stopped");
 }
 
@@ -168,7 +171,8 @@ fn test_non_admin_cannot_add_guardian() {
 #[test]
 fn test_stop_emits_event() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
+    ctx.env
+        .with_mock_all_auths(|| ctx.client().stop(&ctx.admin));
     assert_emitted!(
         ctx.env,
         ctx.id,
@@ -191,7 +195,8 @@ fn test_resume_emits_event() {
 #[test]
 fn test_add_guardian_emits_event() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().add_guardian(&ctx.guardian));
+    ctx.env
+        .with_mock_all_auths(|| ctx.client().add_guardian(&ctx.guardian));
     assert_emitted!(
         ctx.env,
         ctx.id,

--- a/examples/escrow-multi-arbiter/src/test.rs
+++ b/examples/escrow-multi-arbiter/src/test.rs
@@ -52,7 +52,16 @@ impl Ctx {
         let token = MockToken::new(&env, "USDC", 6);
         token.mint(&depositor, AMOUNT * 3);
 
-        Ctx { env, id, depositor, recipient, arbiter_a, arbiter_b, arbiter_c, token }
+        Ctx {
+            env,
+            id,
+            depositor,
+            recipient,
+            arbiter_a,
+            arbiter_b,
+            arbiter_c,
+            token,
+        }
     }
 
     fn client(&self) -> MultiArbiterEscrowClient<'_> {
@@ -138,7 +147,8 @@ fn test_arbiter_a_can_approve() {
     let ctx = Ctx::setup();
     ctx.create_escrow();
 
-    ctx.env.with_mock_all_auths(|| ctx.client().approve(&ctx.arbiter_a));
+    ctx.env
+        .with_mock_all_auths(|| ctx.client().approve(&ctx.arbiter_a));
     assert_eq!(ctx.client().get_state().status, EscrowStatus::Approved);
 }
 
@@ -147,7 +157,8 @@ fn test_arbiter_b_can_approve() {
     let ctx = Ctx::setup();
     ctx.create_escrow();
 
-    ctx.env.with_mock_all_auths(|| ctx.client().approve(&ctx.arbiter_b));
+    ctx.env
+        .with_mock_all_auths(|| ctx.client().approve(&ctx.arbiter_b));
     assert_eq!(ctx.client().get_state().status, EscrowStatus::Approved);
 }
 
@@ -156,7 +167,8 @@ fn test_arbiter_c_can_approve() {
     let ctx = Ctx::setup();
     ctx.create_escrow();
 
-    ctx.env.with_mock_all_auths(|| ctx.client().approve(&ctx.arbiter_c));
+    ctx.env
+        .with_mock_all_auths(|| ctx.client().approve(&ctx.arbiter_c));
     assert_eq!(ctx.client().get_state().status, EscrowStatus::Approved);
 }
 
@@ -195,7 +207,8 @@ fn test_claim_after_arbiter_approval_succeeds_before_timeout() {
     ctx.create_escrow();
 
     // Approve without advancing time.
-    ctx.env.with_mock_all_auths(|| ctx.client().approve(&ctx.arbiter_b));
+    ctx.env
+        .with_mock_all_auths(|| ctx.client().approve(&ctx.arbiter_b));
     ctx.env.with_mock_all_auths(|| ctx.client().claim());
 
     assert_eq!(ctx.token.balance(&ctx.recipient), AMOUNT);

--- a/examples/gasless/src/test.rs
+++ b/examples/gasless/src/test.rs
@@ -79,7 +79,8 @@ impl Ctx {
 fn test_execute_transfers_tokens() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
-    ctx.client().execute(&ctx.relayer.address(), &ctx.meta_tx(0));
+    ctx.client()
+        .execute(&ctx.relayer.address(), &ctx.meta_tx(0));
 
     assert_eq!(ctx.token.balance(&ctx.alice), AMOUNT * 4);
     assert_eq!(ctx.token.balance(&ctx.bob), AMOUNT);
@@ -90,7 +91,8 @@ fn test_nonce_increments_after_execute() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
     assert_eq!(ctx.client().nonce(&ctx.alice), 0);
-    ctx.client().execute(&ctx.relayer.address(), &ctx.meta_tx(0));
+    ctx.client()
+        .execute(&ctx.relayer.address(), &ctx.meta_tx(0));
     assert_eq!(ctx.client().nonce(&ctx.alice), 1);
 }
 
@@ -98,17 +100,24 @@ fn test_nonce_increments_after_execute() {
 fn test_replay_attack_reverts() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
-    ctx.client().execute(&ctx.relayer.address(), &ctx.meta_tx(0));
+    ctx.client()
+        .execute(&ctx.relayer.address(), &ctx.meta_tx(0));
     // Replay with same nonce.
-    assert_reverts!(ctx.client().execute(&ctx.relayer.address(), &ctx.meta_tx(0)), "nonce");
+    assert_reverts!(
+        ctx.client()
+            .execute(&ctx.relayer.address(), &ctx.meta_tx(0)),
+        "nonce"
+    );
 }
 
 #[test]
 fn test_sequential_nonces_succeed() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
-    ctx.client().execute(&ctx.relayer.address(), &ctx.meta_tx(0));
-    ctx.client().execute(&ctx.relayer.address(), &ctx.meta_tx(1));
+    ctx.client()
+        .execute(&ctx.relayer.address(), &ctx.meta_tx(0));
+    ctx.client()
+        .execute(&ctx.relayer.address(), &ctx.meta_tx(1));
     assert_eq!(ctx.token.balance(&ctx.bob), AMOUNT * 2);
 }
 
@@ -119,7 +128,8 @@ fn test_expired_meta_tx_reverts() {
     // Advance time past the deadline.
     ctx.env.advance_time(Duration::seconds(3_601));
     assert_reverts!(
-        ctx.client().execute(&ctx.relayer.address(), &ctx.meta_tx(0)),
+        ctx.client()
+            .execute(&ctx.relayer.address(), &ctx.meta_tx(0)),
         "expired"
     );
 }
@@ -140,7 +150,11 @@ fn test_wrong_nonce_reverts() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
     // Nonce 1 is wrong when 0 is expected.
-    assert_reverts!(ctx.client().execute(&ctx.relayer.address(), &ctx.meta_tx(1)), "nonce");
+    assert_reverts!(
+        ctx.client()
+            .execute(&ctx.relayer.address(), &ctx.meta_tx(1)),
+        "nonce"
+    );
 }
 
 #[test]
@@ -160,7 +174,8 @@ fn test_nonce_starts_at_zero() {
 fn test_execute_emits_event() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
-    ctx.client().execute(&ctx.relayer.address(), &ctx.meta_tx(0));
+    ctx.client()
+        .execute(&ctx.relayer.address(), &ctx.meta_tx(0));
     let matching = ctx
         .env
         .events_matching((soroban_sdk::symbol_short!("executed"),));
@@ -179,7 +194,8 @@ fn test_multiple_users_independent_nonces() {
     ctx.token.mint(&ctx.bob.address(), AMOUNT * 5);
 
     // alice executes nonce 0.
-    ctx.client().execute(&ctx.relayer.address(), &ctx.meta_tx(0));
+    ctx.client()
+        .execute(&ctx.relayer.address(), &ctx.meta_tx(0));
 
     // bob's nonce is still 0 independently.
     let bob_tx = make_meta_tx(

--- a/examples/lending/src/test.rs
+++ b/examples/lending/src/test.rs
@@ -123,7 +123,8 @@ fn test_borrow_above_collateral_factor_reverts() {
 
     ctx.env.mock_all_auths();
     assert_reverts!(
-        ctx.client().borrow(&ctx.borrower.address(), &1_600_000_i128),
+        ctx.client()
+            .borrow(&ctx.borrower.address(), &1_600_000_i128),
         "insufficient pool liquidity"
     );
 }
@@ -132,7 +133,8 @@ fn test_borrow_above_collateral_factor_reverts() {
 fn test_borrow_without_enough_collateral_reverts() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
-    ctx.client().deposit(&ctx.lender.address(), &(LIQUIDITY * 2));
+    ctx.client()
+        .deposit(&ctx.lender.address(), &(LIQUIDITY * 2));
     ctx.client()
         .deposit_collateral(&ctx.borrower.address(), &100_000_i128);
 
@@ -200,7 +202,8 @@ fn test_collateral_withdrawal_requires_healthy_position() {
     let ctx = Ctx::setup();
     ctx.fund_pool_and_collateral();
     ctx.env.mock_all_auths();
-    ctx.client().borrow(&ctx.borrower.address(), &1_000_000_i128);
+    ctx.client()
+        .borrow(&ctx.borrower.address(), &1_000_000_i128);
 
     assert_reverts!(
         ctx.client()
@@ -216,7 +219,8 @@ fn test_collateral_can_be_withdrawn_after_repay() {
     ctx.env.mock_all_auths();
     ctx.client().borrow(&ctx.borrower.address(), &500_000_i128);
     ctx.client().repay(&ctx.borrower.address(), &500_000_i128);
-    ctx.client().withdraw_collateral(&ctx.borrower.address(), &COLLATERAL);
+    ctx.client()
+        .withdraw_collateral(&ctx.borrower.address(), &COLLATERAL);
 
     assert_eq!(ctx.client().position(&ctx.borrower).collateral, 0);
     assert_eq!(ctx.collateral.balance(&ctx.borrower), COLLATERAL);

--- a/examples/prediction-market/src/test.rs
+++ b/examples/prediction-market/src/test.rs
@@ -113,8 +113,11 @@ fn test_double_initialize_reverts() {
     let ctx = Ctx::setup();
     ctx.initialize();
     assert_reverts!(
-        ctx.client()
-            .initialize(&ctx.admin.address(), &ctx.token.address(), &(BASE_TIME + CLOSE_DELAY)),
+        ctx.client().initialize(
+            &ctx.admin.address(),
+            &ctx.token.address(),
+            &(BASE_TIME + CLOSE_DELAY)
+        ),
         "already initialized"
     );
 }
@@ -124,7 +127,8 @@ fn test_buy_transfers_collateral_and_tracks_position() {
     let ctx = Ctx::setup();
     ctx.initialize();
     ctx.env.mock_all_auths();
-    ctx.client().buy(&ctx.alice.address(), &Outcome::Yes, &ALICE_STAKE);
+    ctx.client()
+        .buy(&ctx.alice.address(), &Outcome::Yes, &ALICE_STAKE);
 
     assert_eq!(
         ctx.client().position(&ctx.alice.address(), &Outcome::Yes),
@@ -140,12 +144,18 @@ fn test_buy_accumulates_multiple_positions() {
     let ctx = Ctx::setup();
     ctx.initialize();
     ctx.env.mock_all_auths();
-    ctx.client().buy(&ctx.alice.address(), &Outcome::Yes, &ALICE_STAKE);
-    ctx.client().buy(&ctx.alice.address(), &Outcome::Yes, &BOB_STAKE);
-    ctx.client().buy(&ctx.carol.address(), &Outcome::No, &CAROL_STAKE);
+    ctx.client()
+        .buy(&ctx.alice.address(), &Outcome::Yes, &ALICE_STAKE);
+    ctx.client()
+        .buy(&ctx.alice.address(), &Outcome::Yes, &BOB_STAKE);
+    ctx.client()
+        .buy(&ctx.carol.address(), &Outcome::No, &CAROL_STAKE);
 
     let state = ctx.client().get_state();
-    assert_eq!(ctx.client().position(&ctx.alice.address(), &Outcome::Yes), 1_000_000);
+    assert_eq!(
+        ctx.client().position(&ctx.alice.address(), &Outcome::Yes),
+        1_000_000
+    );
     assert_eq!(state.yes_total, 1_000_000);
     assert_eq!(state.no_total, CAROL_STAKE);
 }
@@ -156,7 +166,8 @@ fn test_buy_rejects_zero_amount() {
     ctx.initialize();
     ctx.env.mock_all_auths();
     assert_reverts!(
-        ctx.client().buy(&ctx.alice.address(), &Outcome::Yes, &0_i128),
+        ctx.client()
+            .buy(&ctx.alice.address(), &Outcome::Yes, &0_i128),
         "positive"
     );
 }
@@ -168,7 +179,8 @@ fn test_buy_after_close_reverts() {
     ctx.env.advance_time(Duration::seconds(CLOSE_DELAY));
     ctx.env.mock_all_auths();
     assert_reverts!(
-        ctx.client().buy(&ctx.alice.address(), &Outcome::Yes, &ALICE_STAKE),
+        ctx.client()
+            .buy(&ctx.alice.address(), &Outcome::Yes, &ALICE_STAKE),
         "closed"
     );
 }
@@ -248,7 +260,10 @@ fn test_winners_claim_proportional_payouts() {
         ctx.token.balance(&ctx.bob),
         2_000_000 - BOB_STAKE + bob_expected
     );
-    assert_eq!(ctx.client().position(&ctx.alice.address(), &Outcome::Yes), 0);
+    assert_eq!(
+        ctx.client().position(&ctx.alice.address(), &Outcome::Yes),
+        0
+    );
     assert_eq!(ctx.client().position(&ctx.bob.address(), &Outcome::Yes), 0);
 }
 

--- a/examples/staking/src/test.rs
+++ b/examples/staking/src/test.rs
@@ -65,7 +65,10 @@ impl Ctx {
 #[test]
 fn test_stake_transfers_tokens_to_contract() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None));
+    ctx.env.with_mock_all_auths(|| {
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None)
+    });
 
     assert_eq!(ctx.token.balance(&ctx.id), STAKE_AMOUNT);
     assert_eq!(ctx.token.balance(&ctx.alice), STAKE_AMOUNT * 2);
@@ -74,7 +77,10 @@ fn test_stake_transfers_tokens_to_contract() {
 #[test]
 fn test_stake_self_delegation_by_default() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None));
+    ctx.env.with_mock_all_auths(|| {
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None)
+    });
 
     // Without explicit delegate, voting power goes to self.
     assert_eq!(ctx.client().voting_power(&ctx.alice), STAKE_AMOUNT);
@@ -84,8 +90,11 @@ fn test_stake_self_delegation_by_default() {
 fn test_stake_with_explicit_delegate() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
-    ctx.client()
-        .stake(&ctx.alice.address(), &STAKE_AMOUNT, &Some(ctx.bob.address()));
+    ctx.client().stake(
+        &ctx.alice.address(),
+        &STAKE_AMOUNT,
+        &Some(ctx.bob.address()),
+    );
 
     assert_eq!(ctx.client().voting_power(&ctx.bob), STAKE_AMOUNT);
     assert_eq!(ctx.client().voting_power(&ctx.alice), 0);
@@ -94,7 +103,10 @@ fn test_stake_with_explicit_delegate() {
 #[test]
 fn test_delegate_changes_voting_power() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None));
+    ctx.env.with_mock_all_auths(|| {
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None)
+    });
 
     // Alice delegates to Bob.
     ctx.client().delegate(&ctx.alice.address(), &ctx.bob);
@@ -108,7 +120,8 @@ fn test_delegate_then_redelegate() {
     let ctx = Ctx::setup();
     {
         let _auth = ctx.env.mock_all_auths_scoped();
-        ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None);
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None);
         ctx.client().delegate(&ctx.alice.address(), &ctx.bob);
         ctx.client().delegate(&ctx.alice.address(), &ctx.charlie);
     }
@@ -121,7 +134,10 @@ fn test_delegate_then_redelegate() {
 #[test]
 fn test_unstake_returns_tokens() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None));
+    ctx.env.with_mock_all_auths(|| {
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None)
+    });
     ctx.client().unstake(&ctx.alice);
 
     assert_eq!(ctx.token.balance(&ctx.alice), STAKE_AMOUNT * 3);
@@ -131,7 +147,10 @@ fn test_unstake_returns_tokens() {
 #[test]
 fn test_unstake_removes_voting_power() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None));
+    ctx.env.with_mock_all_auths(|| {
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None)
+    });
     ctx.client().unstake(&ctx.alice);
 
     assert_eq!(ctx.client().voting_power(&ctx.alice), 0);
@@ -141,8 +160,11 @@ fn test_unstake_removes_voting_power() {
 fn test_unstake_removes_delegated_voting_power() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
-    ctx.client()
-        .stake(&ctx.alice.address(), &STAKE_AMOUNT, &Some(ctx.bob.address()));
+    ctx.client().stake(
+        &ctx.alice.address(),
+        &STAKE_AMOUNT,
+        &Some(ctx.bob.address()),
+    );
     ctx.client().unstake(&ctx.alice);
 
     assert_eq!(ctx.client().voting_power(&ctx.bob), 0);
@@ -154,10 +176,16 @@ fn test_multiple_stakers_accumulate_voting_power() {
     {
         let _auth = ctx.env.mock_all_auths_scoped();
         // Both alice and bob delegate to charlie.
-        ctx.client()
-            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &Some(ctx.charlie.address()));
-        ctx.client()
-            .stake(&ctx.bob.address(), &STAKE_AMOUNT, &Some(ctx.charlie.address()));
+        ctx.client().stake(
+            &ctx.alice.address(),
+            &STAKE_AMOUNT,
+            &Some(ctx.charlie.address()),
+        );
+        ctx.client().stake(
+            &ctx.bob.address(),
+            &STAKE_AMOUNT,
+            &Some(ctx.charlie.address()),
+        );
     }
 
     assert_eq!(ctx.client().voting_power(&ctx.charlie), STAKE_AMOUNT * 2);
@@ -167,7 +195,10 @@ fn test_multiple_stakers_accumulate_voting_power() {
 fn test_stake_zero_amount_reverts() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
-    assert_reverts!(ctx.client().stake(&ctx.alice.address(), &0_i128, &None), "positive");
+    assert_reverts!(
+        ctx.client().stake(&ctx.alice.address(), &0_i128, &None),
+        "positive"
+    );
 }
 
 #[test]
@@ -190,7 +221,10 @@ fn test_delegate_without_stake_reverts() {
 #[test]
 fn test_stake_emits_event() {
     let ctx = Ctx::setup();
-    ctx.env.with_mock_all_auths(|| ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None));
+    ctx.env.with_mock_all_auths(|| {
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None)
+    });
     // Verify the staked event is present (alongside the SAC transfer event).
     let matching = ctx
         .env
@@ -203,7 +237,8 @@ fn test_unstake_emits_event() {
     let ctx = Ctx::setup();
     {
         let _auth = ctx.env.mock_all_auths_scoped();
-        ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None);
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None);
         ctx.client().unstake(&ctx.alice);
     }
     let matching = ctx
@@ -220,7 +255,8 @@ fn test_delegate_emits_event() {
     let ctx = Ctx::setup();
     {
         let _auth = ctx.env.mock_all_auths_scoped();
-        ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None);
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None);
         ctx.client().delegate(&ctx.alice.address(), &ctx.bob);
     }
     let matching = ctx
@@ -236,8 +272,11 @@ fn test_delegate_emits_event() {
 fn test_get_stake_returns_correct_info() {
     let ctx = Ctx::setup();
     ctx.env.with_mock_all_auths(|| {
-        ctx.client()
-            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &Some(ctx.bob.address()));
+        ctx.client().stake(
+            &ctx.alice.address(),
+            &STAKE_AMOUNT,
+            &Some(ctx.bob.address()),
+        );
     });
 
     let info = ctx.client().get_stake(&ctx.alice);
@@ -258,8 +297,10 @@ fn test_additional_stake_accumulates() {
     let ctx = Ctx::setup();
     {
         let _auth = ctx.env.mock_all_auths_scoped();
-        ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None);
-        ctx.client().stake(&ctx.alice.address(), &STAKE_AMOUNT, &None);
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None);
+        ctx.client()
+            .stake(&ctx.alice.address(), &STAKE_AMOUNT, &None);
     }
 
     let info = ctx.client().get_stake(&ctx.alice);

--- a/examples/time_locked_vault/src/lib.rs
+++ b/examples/time_locked_vault/src/lib.rs
@@ -54,7 +54,11 @@ impl TimeLockedVault {
         }
         owner.require_auth();
 
-        token::TokenClient::new(&env, &token).transfer(&owner, &env.current_contract_address(), &amount);
+        token::TokenClient::new(&env, &token).transfer(
+            &owner,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         let id: u64 = env
             .storage()

--- a/examples/time_locked_vault/src/test.rs
+++ b/examples/time_locked_vault/src/test.rs
@@ -169,8 +169,12 @@ fn test_deposit_past_unlock_time_reverts() {
     ctx.env.mock_all_auths();
     // unlock_time in the past
     assert_reverts!(
-        ctx.client()
-            .deposit(&ctx.alice.address(), &ctx.token.address(), &AMOUNT, &(BASE_TIME - 1)),
+        ctx.client().deposit(
+            &ctx.alice.address(),
+            &ctx.token.address(),
+            &AMOUNT,
+            &(BASE_TIME - 1)
+        ),
         "future"
     );
 }
@@ -185,9 +189,12 @@ fn test_multiple_depositors_independent() {
         &AMOUNT,
         &ctx.unlock_time(),
     );
-    let id_b = ctx
-        .client()
-        .deposit(&ctx.bob.address(), &ctx.token.address(), &AMOUNT, &ctx.unlock_time());
+    let id_b = ctx.client().deposit(
+        &ctx.bob.address(),
+        &ctx.token.address(),
+        &AMOUNT,
+        &ctx.unlock_time(),
+    );
 
     ctx.env.advance_time(Duration::seconds(LOCK_DURATION + 1));
     ctx.client().withdraw(&id_a);

--- a/examples/token/src/test.rs
+++ b/examples/token/src/test.rs
@@ -70,8 +70,8 @@ fn test_mint_without_auth_reverts() {
         .build();
     let id = env.contract_id::<Token>();
     let admin = env.account("alice"); // wrong admin address
-    // Do not mock auths; this should trigger auth failure
-    // env.mock_all_auths(); // removed to test real auth behavior
+                                      // Do not mock auths; this should trigger auth failure
+                                      // env.mock_all_auths(); // removed to test real auth behavior
     TokenClient::new(env.inner(), &id).initialize(&admin);
     assert_reverts!(
         TokenClient::new(env.inner(), &id).mint(&env.account("alice"), &0_i128),

--- a/examples/vesting/src/lib.rs
+++ b/examples/vesting/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![allow(deprecated)]
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, panic_with_error, token, Address, Env};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, token, Address, Env,
+};
 
 /// Persistent state for the vesting schedule.
 #[contracttype]

--- a/examples/vesting/src/test.rs
+++ b/examples/vesting/src/test.rs
@@ -4,7 +4,7 @@ extern crate std;
 use crucible::assert_reverts;
 use crucible::prelude::*;
 
-use crate::{Vesting, VestingClient, ContractError};
+use crate::{ContractError, Vesting, VestingClient};
 use soroban_sdk::testutils::Ledger;
 
 // ---------------------------------------------------------------------------
@@ -207,12 +207,12 @@ fn test_initialize_overflow_start_plus_cliff() {
     token.mint(&admin, TOTAL);
 
     env.mock_all_auths();
-    
+
     // start + cliff overflows (u64::MAX + 1)
     let start = u64::MAX;
     let cliff = 1;
     let duration = 100;
-    
+
     let res = VestingClient::new(env.inner(), &id).try_initialize(
         &admin,
         &beneficiary,
@@ -222,7 +222,7 @@ fn test_initialize_overflow_start_plus_cliff() {
         &cliff,
         &duration,
     );
-    
+
     assert!(res.is_err());
     let err = res.err().unwrap();
     match err {
@@ -253,12 +253,12 @@ fn test_initialize_overflow_cliff_end_plus_duration() {
     token.mint(&admin, TOTAL);
 
     env.mock_all_auths();
-    
+
     // cliff_end + duration overflows (u64::MAX - 100 + 50 + 51 = u64::MAX + 1)
     let start = u64::MAX - 100;
     let cliff = 50;
     let duration = 51;
-    
+
     let res = VestingClient::new(env.inner(), &id).try_initialize(
         &admin,
         &beneficiary,
@@ -268,7 +268,7 @@ fn test_initialize_overflow_cliff_end_plus_duration() {
         &cliff,
         &duration,
     );
-    
+
     assert!(res.is_err());
     let err = res.err().unwrap();
     match err {
@@ -299,12 +299,12 @@ fn test_initialize_near_max_valid_schedule() {
     token.mint(&admin, TOTAL);
 
     env.mock_all_auths();
-    
+
     // Valid near-max (u64::MAX - 100 + 50 + 50 = u64::MAX, no overflow)
     let start = u64::MAX - 100;
     let cliff = 50;
     let duration = 50;
-    
+
     let client = VestingClient::new(env.inner(), &id);
     client.initialize(
         &admin,
@@ -315,17 +315,19 @@ fn test_initialize_near_max_valid_schedule() {
         &cliff,
         &duration,
     );
-    
+
     // Check vested amounts at boundaries
     env.inner().ledger().set_timestamp(start + cliff - 1);
     assert_eq!(client.vested(), 0);
-    
+
     env.inner().ledger().set_timestamp(start + cliff);
     assert_eq!(client.vested(), 0);
-    
-    env.inner().ledger().set_timestamp(start + cliff + duration / 2);
+
+    env.inner()
+        .ledger()
+        .set_timestamp(start + cliff + duration / 2);
     assert_eq!(client.vested(), TOTAL / 2);
-    
+
     env.inner().ledger().set_timestamp(start + cliff + duration);
     assert_eq!(client.vested(), TOTAL);
 }


### PR DESCRIPTION
closes #792 [Docs] Add CONTRIBUTING.md section explaining how to add a new example contract
 closes #791 [Enhancement] Implement env.events_in_order() to assert event emission sequence
closes #790 [Backend] Add Prometheus histogram for HTTP request duration bucketed by route and status code
closes #793 [Backend] Implement idempotency key support for POST /api/alerts/ingest to prevent duplicate alert ingestion