### PR TITLE
feat : Add /health/startup endpoint for Kubernetes startup probe dist…

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,97 @@
+name: Crucible Benchmarks
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/crucible/**'
+      - 'backend/benches/**'
+      - '.github/workflows/bench.yml'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  benchmark:
+    name: Run Criterion Benchmarks
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bench-
+
+      - name: Run benchmarks
+        run: |
+          cargo bench --workspace -- --output-format bencher | tee bench_output.txt
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.sha }}
+          path: |
+            bench_output.txt
+            target/criterion/**/*
+          retention-days: 90
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        if: github.ref == 'refs/heads/main'
+        with:
+          name: Crucible Benchmarks
+          tool: 'cargo'
+          output-file-path: bench_output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Save benchmark data to gh-pages branch
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+          alert-comment-cc-users: '@benelabs'
+
+      - name: Comment benchmark summary on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('bench_output.txt', 'utf8');
+            const lines = output.split('\n').slice(0, 50); // First 50 lines
+            const body = `## 📊 Benchmark Results\n\n\`\`\`\n${lines.join('\n')}\n\`\`\`\n\nFull results available in workflow artifacts.`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
+      - name: Generate benchmark report summary
+        run: |
+          echo "## Benchmark Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          head -n 30 bench_output.txt >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📦 Full benchmark results uploaded as artifacts" >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,53 @@ cargo build --package crucible --target wasm32-unknown-unknown
 
 text
 
+## Benchmarks
+
+Crucible uses [Criterion](https://github.com/bheisler/criterion.rs) for performance benchmarks. Benchmarks are located in:
+
+- `backend/benches/` — Backend API performance benchmarks
+- Contract-specific benchmark files
+
+**Running benchmarks locally:**
+
+```sh
+cargo bench --workspace
+```
+
+**Benchmark CI:**
+
+- Benchmarks run automatically on every push to `main`
+- Results are uploaded as workflow artifacts
+- Historical trends are tracked in the `gh-pages` branch
+- View trends at: `https://benelabs.github.io/crucible/dev/bench/`
+
+**Adding new benchmarks:**
+
+1. Create a benchmark file in the appropriate `benches/` directory
+2. Use stable benchmark names (avoid dynamic IDs) for trend tracking
+3. Document what the benchmark measures and why it matters
+4. Keep benchmarks fast (< 10 seconds per run)
+
+**Example benchmark:**
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn bench_mock_env_builder(c: &mut Criterion) {
+    c.bench_function("MockEnv::build with 10 contracts", |b| {
+        b.iter(|| {
+            let env = MockEnv::builder()
+                .with_contracts(black_box(10))
+                .build();
+            env
+        });
+    });
+}
+
+criterion_group!(benches, bench_mock_env_builder);
+criterion_main!(benches);
+```
+
 ## Workspace Structure
 
 | Crate | Description |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prometheus",
+ "proptest",
  "redis",
  "regex",
  "reqwest",
@@ -547,6 +548,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1214,6 +1230,13 @@ dependencies = [
  "quote",
  "syn 2.0.118",
  "trybuild",
+]
+
+[[package]]
+name = "crucible-proxy"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -3597,6 +3620,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +3715,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -3840,6 +3888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4304,6 +4361,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5905,6 +5974,7 @@ dependencies = [
 name = "treasury"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -5969,6 +6039,12 @@ dependencies = [
  "rand 0.9.4",
  "web-time",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -6159,6 +6235,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -363,6 +363,10 @@ let balance = usdc.balance(&env.account("alice").address());
 // Admin operations
 usdc.set_admin(&new_admin_address);
 usdc.clawback(&target_address, &amount);
+
+// Convenience helpers for full balance operations
+usdc.clawback_all(&target_address); // Removes all tokens (no manual balance lookup)
+usdc.burn_all(&holder_address);    // Burns entire balance
 ```
 
 `MockToken` implements the full SEP-41 / SAC interface, so you can pass its `Address` directly into any contract that expects a token contract address.

--- a/backend/src/api/handlers/health.rs
+++ b/backend/src/api/handlers/health.rs
@@ -1,20 +1,27 @@
 //! Health check endpoints.
 //!
-//! Provides two endpoints:
+//! Provides three endpoints:
 //!
-//! - `GET /health/live`  — liveness probe: returns 200 if the process is running.
-//! - `GET /health/ready` — readiness probe: returns 200 only when PostgreSQL,
+//! - `GET /health/live`    — liveness probe: returns 200 if the process is running.
+//! - `GET /health/ready`   — readiness probe: returns 200 only when PostgreSQL,
 //!   Redis, and the worker queue are reachable; returns 503 otherwise.
+//! - `GET /health/startup` — startup probe: returns 503 until full startup is
+//!   complete (migrations, Redis, workers), then returns 200 permanently.
 //!
-//! Both endpoints return a JSON body with per-component status details so that
-//! operators can quickly identify which dependency is unhealthy. Connection
-//! strings, hostnames, and credentials are never included in responses.
+//! Both liveness and readiness endpoints return a JSON body with per-component
+//! status details so that operators can quickly identify which dependency is
+//! unhealthy. Connection strings, hostnames, and credentials are never included
+//! in responses.
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use redis::aio::ConnectionManager;
 use serde::Serialize;
 use sqlx::PgPool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::{debug, instrument, warn};
+
+/// Tracks whether the application has completed its initial startup sequence.
+static STARTUP_COMPLETE: AtomicBool = AtomicBool::new(false);
 
 /// Minimal application state required by health check handlers.
 #[derive(Clone)]
@@ -60,6 +67,14 @@ pub struct HealthReport {
 #[derive(Debug, Serialize)]
 pub struct LivenessResponse {
     pub status: &'static str,
+    pub version: String,
+}
+
+/// Response body for the startup probe.
+#[derive(Debug, Serialize)]
+pub struct StartupResponse {
+    pub status: &'static str,
+    pub ready: bool,
     pub version: String,
 }
 
@@ -120,6 +135,106 @@ pub async fn readiness(State(state): State<HealthState>) -> impl IntoResponse {
             version: env!("CARGO_PKG_VERSION").to_string(),
         }),
     )
+}
+
+/// `GET /health/startup` — startup probe.
+///
+/// Returns `503 Service Unavailable` while the application is initializing
+/// (database migrations, Redis connection, worker queue setup). Once startup
+/// completes and this endpoint returns `200 OK` for the first time, it will
+/// continue to return `200 OK` permanently, even if dependencies later become
+/// unavailable.
+///
+/// This differs from the readiness probe, which can transition back to 503
+/// during transient failures. Kubernetes uses startup probes to delay liveness
+/// and readiness checks until the container is fully initialized.
+///
+/// Call [`mark_startup_complete()`] after all initialization is done to signal
+/// that this endpoint should return 200.
+#[instrument(skip_all)]
+pub async fn startup(State(state): State<HealthState>) -> impl IntoResponse {
+    // Once startup is marked complete, always return 200
+    if STARTUP_COMPLETE.load(Ordering::Relaxed) {
+        debug!("Startup probe: already completed");
+        return (
+            StatusCode::OK,
+            Json(StartupResponse {
+                status: "ok",
+                ready: true,
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            }),
+        );
+    }
+
+    // Check if all dependencies are available
+    let database = check_database(&state.db).await;
+    let redis = check_cache(&state.cache).await;
+    let queue = check_queue(&state.queue).await;
+
+    let all_ready = database.status == "up" && redis.status == "up" && queue.status == "up";
+
+    if all_ready {
+        // Mark startup as complete (first successful check)
+        STARTUP_COMPLETE.store(true, Ordering::Relaxed);
+        debug!("Startup probe: marking startup as complete");
+        (
+            StatusCode::OK,
+            Json(StartupResponse {
+                status: "ok",
+                ready: true,
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            }),
+        )
+    } else {
+        debug!("Startup probe: still initializing");
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(StartupResponse {
+                status: "initializing",
+                ready: false,
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            }),
+        )
+    }
+}
+
+/// Marks the application startup sequence as complete.
+///
+/// Call this after all initialization is done (database migrations, Redis
+/// connection, worker queue setup). After calling this, the `/health/startup`
+/// endpoint will permanently return `200 OK`.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use backend::api::handlers::health;
+///
+/// async fn initialize_app() {
+///     // Run migrations
+///     run_migrations().await;
+///     
+///     // Initialize Redis
+///     setup_redis().await;
+///     
+///     // Start workers
+///     start_workers().await;
+///     
+///     // Mark startup complete
+///     health::mark_startup_complete();
+/// }
+/// # async fn run_migrations() {}
+/// # async fn setup_redis() {}
+/// # async fn start_workers() {}
+/// ```
+pub fn mark_startup_complete() {
+    STARTUP_COMPLETE.store(true, Ordering::Relaxed);
+    tracing::info!("Application startup marked as complete");
+}
+
+/// Resets the startup completion flag. This is primarily for testing.
+#[cfg(test)]
+pub fn reset_startup_flag() {
+    STARTUP_COMPLETE.store(false, Ordering::Relaxed);
 }
 
 // ---------------------------------------------------------------------------
@@ -261,6 +376,7 @@ pub fn router() -> axum::Router<HealthState> {
     axum::Router::new()
         .route("/live", get(liveness))
         .route("/ready", get(readiness))
+        .route("/startup", get(startup))
 }
 
 // ---------------------------------------------------------------------------
@@ -367,5 +483,48 @@ mod tests {
             json["checks"]["queue"]["message"],
             "workers unavailable"
         );
+    }
+
+    #[test]
+    fn startup_response_serializes() {
+        let response = StartupResponse {
+            status: "ok",
+            ready: true,
+            version: "0.1.0".into(),
+        };
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["ready"], true);
+        assert_eq!(json["version"], "0.1.0");
+    }
+
+    #[test]
+    fn startup_response_serializes_initializing() {
+        let response = StartupResponse {
+            status: "initializing",
+            ready: false,
+            version: "0.1.0".into(),
+        };
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["status"], "initializing");
+        assert_eq!(json["ready"], false);
+        assert_eq!(json["version"], "0.1.0");
+    }
+
+    #[test]
+    fn mark_startup_complete_sets_flag() {
+        use super::reset_startup_flag;
+        
+        // Reset to initial state
+        reset_startup_flag();
+        
+        // Mark complete
+        super::mark_startup_complete();
+        
+        // Verify flag is set
+        assert_eq!(super::STARTUP_COMPLETE.load(std::sync::atomic::Ordering::Relaxed), true);
+        
+        // Clean up
+        reset_startup_flag();
     }
 }

--- a/contracts/crucible/src/env.rs
+++ b/contracts/crucible/src/env.rs
@@ -585,6 +585,11 @@ impl MockEnv {
     /// # Panics
     /// Panics if the timestamp overflows.
     pub fn advance_time(&self, duration: Duration) {
+        // Guard: zero duration is a no-op
+        if duration.as_seconds() == 0 {
+            return;
+        }
+
         let info = self.inner.ledger().get();
         let new_ts = info
             .timestamp
@@ -642,6 +647,11 @@ impl MockEnv {
 
     /// Advance the ledger sequence number by n.
     pub fn advance_sequence(&self, n: u32) {
+        // Guard: zero is a no-op
+        if n == 0 {
+            return;
+        }
+
         let info = self.inner.ledger().get();
         self.inner.ledger().set(soroban_sdk::testutils::LedgerInfo {
             sequence_number: info.sequence_number + n,
@@ -1507,7 +1517,7 @@ mod extra_tests {
 #[cfg(test)]
 mod time_advance_tests {
     use super::*;
-    use crate::time::{add_months, datetime_to_unix};
+    use crate::time_helpers::{add_months, datetime_to_unix};
 
     const JAN_31_2024: u64 = 1_706_704_245;
     const MAR_15_2024: u64 = 1_710_489_600;
@@ -1534,6 +1544,36 @@ mod time_advance_tests {
         let env = MockEnv::builder().at_timestamp(MAR_15_2024).build();
         env.advance_time_by_months(6);
         assert_eq!(env.timestamp(), add_months(MAR_15_2024, 6));
+    }
+
+    #[test]
+    fn advance_time_zero_duration_is_noop() {
+        let env = MockEnv::builder()
+            .at_timestamp(1_700_000_000)
+            .build();
+        
+        // Verify initial state
+        assert_eq!(env.timestamp(), 1_700_000_000);
+        
+        // Advance by zero using Duration::ZERO equivalent
+        env.advance_time(Duration::days(0));
+        
+        // Timestamp should remain unchanged
+        assert_eq!(env.timestamp(), 1_700_000_000);
+        
+        // Also test with Duration::seconds(0)
+        env.advance_time(Duration::seconds(0));
+        assert_eq!(env.timestamp(), 1_700_000_000);
+    }
+
+    #[test]
+    fn advance_sequence_zero_is_noop() {
+        let env = MockEnv::builder().build();
+        let initial_seq = env.ledger_sequence();
+        
+        env.advance_sequence(0);
+        
+        assert_eq!(env.ledger_sequence(), initial_seq);
     }
 }
 

--- a/contracts/crucible/src/token.rs
+++ b/contracts/crucible/src/token.rs
@@ -449,6 +449,66 @@ impl MockToken {
         let client = StellarAssetClient::new(&self.env, &self.address);
         client.clawback(from, &amount);
     }
+
+    /// Claws back all tokens from an account (admin operation).
+    ///
+    /// This is a convenience method that automatically retrieves the account's
+    /// balance and claws back the entire amount. If the account has zero balance,
+    /// this is a no-op.
+    ///
+    /// # Arguments
+    ///
+    /// * `from` - The address to claw back all tokens from
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use crucible::prelude::*;
+    /// let env = MockEnv::builder().build();
+    /// let token = MockToken::xlm(&env);
+    /// let alice = env.account("alice");
+    /// 
+    /// token.mint(&alice.address(), 1_000_000);
+    /// token.clawback_all(&alice.address());
+    /// assert_eq!(token.balance(&alice.address()), 0);
+    /// ```
+    pub fn clawback_all(&self, from: &Address) {
+        let balance = self.balance(from);
+        if balance == 0 {
+            return; // No-op for zero balance
+        }
+        self.clawback(from, balance);
+    }
+
+    /// Burns all tokens from the specified account.
+    ///
+    /// This is a convenience method that automatically retrieves the account's
+    /// balance and burns the entire amount. If the account has zero balance,
+    /// this is a no-op.
+    ///
+    /// # Arguments
+    ///
+    /// * `from` - The address to burn all tokens from
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use crucible::prelude::*;
+    /// let env = MockEnv::builder().build();
+    /// let token = MockToken::xlm(&env);
+    /// let alice = env.account("alice");
+    /// 
+    /// token.mint(&alice.address(), 1_000_000);
+    /// token.burn_all(&alice.address());
+    /// assert_eq!(token.balance(&alice.address()), 0);
+    /// ```
+    pub fn burn_all(&self, from: &Address) {
+        let balance = self.balance(from);
+        if balance == 0 {
+            return; // No-op for zero balance
+        }
+        self.burn(from, balance);
+    }
 }
 
 /// Converts a human-readable display amount to base units.
@@ -972,5 +1032,112 @@ mod tests {
 
         // Admin should be different from token address
         assert_ne!(admin, token.address());
+    }
+
+    // ── clawback_all and burn_all helpers ────────────────────────────────────
+
+    #[test]
+    fn test_clawback_all_removes_entire_balance() {
+        let env = MockEnv::builder()
+            .with_account("alice", Stroops::from(0))
+            .build();
+
+        let token = MockToken::xlm(&env);
+        let alice = env.account("alice");
+
+        // Mint tokens to alice
+        token.mint(&alice.address(), 1_000_000);
+        assert_eq!(token.balance(&alice.address()), 1_000_000);
+
+        // Claw back all tokens
+        token.clawback_all(&alice.address());
+
+        // Balance should be zero
+        assert_eq!(token.balance(&alice.address()), 0);
+    }
+
+    #[test]
+    fn test_clawback_all_with_zero_balance_is_noop() {
+        let env = MockEnv::builder()
+            .with_account("alice", Stroops::from(0))
+            .build();
+
+        let token = MockToken::xlm(&env);
+        let alice = env.account("alice");
+
+        // Alice has no tokens
+        assert_eq!(token.balance(&alice.address()), 0);
+
+        // Clawback all should be a no-op (not panic)
+        token.clawback_all(&alice.address());
+
+        // Balance should still be zero
+        assert_eq!(token.balance(&alice.address()), 0);
+    }
+
+    #[test]
+    fn test_burn_all_removes_entire_balance() {
+        let env = MockEnv::builder()
+            .with_account("alice", Stroops::from(0))
+            .build();
+
+        let token = MockToken::xlm(&env);
+        let alice = env.account("alice");
+
+        // Mint tokens to alice
+        token.mint(&alice.address(), 2_500_000);
+        assert_eq!(token.balance(&alice.address()), 2_500_000);
+
+        // Burn all tokens
+        token.burn_all(&alice.address());
+
+        // Balance should be zero
+        assert_eq!(token.balance(&alice.address()), 0);
+    }
+
+    #[test]
+    fn test_burn_all_with_zero_balance_is_noop() {
+        let env = MockEnv::builder()
+            .with_account("alice", Stroops::from(0))
+            .build();
+
+        let token = MockToken::xlm(&env);
+        let alice = env.account("alice");
+
+        // Alice has no tokens
+        assert_eq!(token.balance(&alice.address()), 0);
+
+        // Burn all should be a no-op (not panic)
+        token.burn_all(&alice.address());
+
+        // Balance should still be zero
+        assert_eq!(token.balance(&alice.address()), 0);
+    }
+
+    #[test]
+    fn test_clawback_all_vs_manual_balance_lookup() {
+        let env = MockEnv::builder()
+            .with_account("alice", Stroops::from(0))
+            .with_account("bob", Stroops::from(0))
+            .build();
+
+        let token = MockToken::xlm(&env);
+        let alice = env.account("alice");
+        let bob = env.account("bob");
+
+        // Set up: mint tokens to both
+        token.mint(&alice.address(), 1_000_000);
+        token.mint(&bob.address(), 1_000_000);
+
+        // Old way: manual balance lookup
+        let balance = token.balance(&alice.address());
+        token.clawback(&alice.address(), balance);
+
+        // New way: helper
+        token.clawback_all(&bob.address());
+
+        // Both should have zero balance
+        assert_eq!(token.balance(&alice.address()), 0);
+        assert_eq!(token.balance(&bob.address()), 0);
     }
 }


### PR DESCRIPTION
closes #796 [Backend] Add /health/startup endpoint for Kubernetes startup probe distinct from /health/live and /health/ready
closes #797 [Enhancement] Publish crucible benchmarks as GitHub Actions job artifact to track performance over time
closes #794 [Enhancement] Add MockToken::clawback_all() helper for testing admin confiscation scenarios
closes #795 [Bug] env.advance_time() with Duration::days(0) resets timestamp to epoch instead of no-op